### PR TITLE
Add support for VS

### DIFF
--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -22,6 +22,7 @@ if (options.config) {
 } else {
     const parserOptions: ParserOptions = {
         eventPrefix: options.eventPrefix,
+        propertyPrefix: options.propertyPrefix,
         applyEndpoints: options.applyEndpoints,
         patchDebugEvents: false,
         lowerCaseEvents: false,

--- a/src/lib/source-spec.ts
+++ b/src/lib/source-spec.ts
@@ -7,6 +7,7 @@ import { cwd } from 'process';
 
 export interface ParserOptions {
     eventPrefix: string;
+    propertyPrefix: string;
     applyEndpoints: boolean;
     patchDebugEvents: boolean;
     lowerCaseEvents: boolean;
@@ -33,6 +34,7 @@ export function convertConfigToSourceSpecs(file: PathLike): SourceSpec[] {
             spec.lowerCaseEvents = spec.lowerCaseEvents ? spec.lowerCaseEvents : false;
             const parserOptions: ParserOptions = {
                 eventPrefix: spec.eventPrefix ? spec.eventPrefix : '',
+                propertyPrefix: spec.propertyPrefix ? spec.propertyPrefix : '',
                 applyEndpoints: spec.applyEndpoints,
                 patchDebugEvents: spec.patchDebugEvents,
                 lowerCaseEvents: spec.lowerCaseEvents,

--- a/src/tests/mocha/declaration-tests.ts
+++ b/src/tests/mocha/declaration-tests.ts
@@ -52,6 +52,7 @@ describe('GDPR Declaration Tests', () => {
     it('resolve declarations', async () => {
         const parserOptions: ParserOptions = {
             eventPrefix: '',
+            propertyPrefix: '',
             applyEndpoints: true,
             patchDebugEvents: false,
             lowerCaseEvents: false,

--- a/src/tests/mocha/event-tests.ts
+++ b/src/tests/mocha/event-tests.ts
@@ -61,6 +61,7 @@ describe('Resolve Tests', () => {
     it('resolve inline + include', async () => {
         const parserOptions: ParserOptions = {
             eventPrefix: '',
+            propertyPrefix: '',
             applyEndpoints: true,
             patchDebugEvents: false,
             lowerCaseEvents: false,

--- a/src/tests/mocha/fragment-tests.ts
+++ b/src/tests/mocha/fragment-tests.ts
@@ -47,6 +47,7 @@ describe('GDPR Fragments', () => {
         it('Resolve inlines + includes', async () => {
             const parserOptions: ParserOptions = {
                 eventPrefix: '',
+                propertyPrefix: '',
                 applyEndpoints: true,
                 patchDebugEvents: false,
                 lowerCaseEvents: false,
@@ -78,6 +79,7 @@ describe('GDPR Fragments', () => {
             const hardSource = path.join(cwd(), 'src/tests/mocha/resources/difficult-include');
             const parserOptions: ParserOptions = {
                 eventPrefix: '',
+                propertyPrefix: '',
                 applyEndpoints: true,
                 patchDebugEvents: false,
                 lowerCaseEvents: false,


### PR DESCRIPTION
On the VS JS Debugger we add the prefix: "vs.bpt.diagnostics.debugadapter." to all properties.
Added the propertyPrefix feature to support this.
Also adding escaping so the property versionv8 would be converted to versionv<NUMBER>