### PR TITLE
bump ripgrep to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/telemetry-extractor",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/telemetry-extractor",
-      "version": "1.9.8",
+      "version": "1.9.9",
       "license": "MIT",
       "dependencies": {
         "@vscode/ripgrep": "^1.15.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.9.8",
       "license": "MIT",
       "dependencies": {
-        "@vscode/ripgrep": "^1.14.2",
+        "@vscode/ripgrep": "^1.15.0",
         "command-line-args": "^5.2.1",
         "ts-morph": "^15.1.0"
       },
@@ -674,9 +674,9 @@
       "dev": true
     },
     "node_modules/@vscode/ripgrep": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.14.2.tgz",
-      "integrity": "sha512-KDaehS8Jfdg1dqStaIPDKYh66jzKd5jy5aYEPzIv0JYFLADPsCSQPBUdsJVXnr0t72OlDcj96W05xt/rSnNFFQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.0.tgz",
+      "integrity": "sha512-qbLYP3XPTfS5a80+WnGvDLhsD01LDrs03zjbbtWWnvwt8G9hP3j8mc3ckaIid7pj86MBSTyUb/ECaIWmJIGBYw==",
       "hasInstallScript": true,
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
@@ -3451,9 +3451,9 @@
       "dev": true
     },
     "@vscode/ripgrep": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.14.2.tgz",
-      "integrity": "sha512-KDaehS8Jfdg1dqStaIPDKYh66jzKd5jy5aYEPzIv0JYFLADPsCSQPBUdsJVXnr0t72OlDcj96W05xt/rSnNFFQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.15.0.tgz",
+      "integrity": "sha512-qbLYP3XPTfS5a80+WnGvDLhsD01LDrs03zjbbtWWnvwt8G9hP3j8mc3ckaIid7pj86MBSTyUb/ECaIWmJIGBYw==",
       "requires": {
         "https-proxy-agent": "^5.0.0",
         "proxy-from-env": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/telemetry-extractor",
-  "version": "1.9.8",
+  "version": "1.9.9",
   "description": "Extracts telemetry from VS Code",
   "main": "out/index.js",
   "typings": "vscode-telemetry-extractor.d.ts",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "command-line-args": "^5.2.1",
     "ts-morph": "^15.1.0",
-    "@vscode/ripgrep": "^1.14.2"
+    "@vscode/ripgrep": "^1.15.0"
   },
   "devDependencies": {
     "@types/command-line-args": "^5.2.0",


### PR DESCRIPTION
New version of vscode-ripgrep is available, this accompanies vscode core upgrading to vscode-ripgrep 1.15.0
https://github.com/microsoft/vscode/pull/177005