### PR TITLE
Try escaping quotes

### DIFF
--- a/src/lib/ts-parser.ts
+++ b/src/lib/ts-parser.ts
@@ -132,7 +132,7 @@ export class TsParser {
         for (const fg of fileGlobs) {
             rg_glob += ` --glob ${fg}`;
         }
-        const cmd = `${rgPath} --files-with-matches ${rg_glob} --no-ignore 'publicLog2|publicLogError2' ${this.sourceDir}`;
+        const cmd = `${rgPath} --files-with-matches ${rg_glob} --no-ignore \"publicLog2|publicLogError2\" ${this.sourceDir}`;
         try {
             const retrieved_paths = cp.execSync(cmd, { encoding: 'ascii' });
             // Split the paths into an array


### PR DESCRIPTION
Attempt to fix #21

The suggested fix of `execFileSync` does not appear to work and causes all tests to fail. My guess is that there is a quoting problem, so here we try and escape the quotes.