### PR TITLE
Fix bug where lowercase events would create bad reports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,8 @@
                 "--sourceDir=${workspaceRoot}/src/telemetry-sources/vscode",
                 "--excludedDirPattern=extensions",
                 "--outputDir=${workspaceRoot}",
-                "--applyEndpoints"
+                "--applyEndpoints",
+                "--lowerCaseEvents"
 
             ]
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vscode/telemetry-extractor",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vscode/telemetry-extractor",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "license": "MIT",
       "dependencies": {
         "@vscode/ripgrep": "^1.15.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/telemetry-extractor",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Extracts telemetry from VS Code",
   "main": "out/index.js",
   "typings": "vscode-telemetry-extractor.d.ts",

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -26,6 +26,7 @@ export const optionDefinitions = [
     { name: 'help', alias: 'h', type: Boolean, description: 'Displays the help dialog which provides more information on how to use the tool', defaultValue: false },
     { name: 'applyEndpoints', alias: 'e', type: Boolean, defaultValue: false },
     { name: 'silenceOutput', type: Boolean, description: 'Silences all progress messages.', defaultValue: false },
+    { name: 'lowerCaseEvents', alias: 'l', type: Boolean, defaultValue: false },
     { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
 ];
 

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -24,7 +24,7 @@ if (options.config) {
         eventPrefix: options.eventPrefix,
         applyEndpoints: options.applyEndpoints,
         patchDebugEvents: false,
-        lowerCaseEvents: false,
+        lowerCaseEvents: options.lowerCaseEvents,
         silenceOutput: options.silenceOutput,
         verbose: options.verbose
     };

--- a/src/lib/ts-parser.ts
+++ b/src/lib/ts-parser.ts
@@ -6,7 +6,7 @@ import * as cp from 'child_process';
 import * as path from 'path';
 import { rgPath } from "@vscode/ripgrep";
 import { makeExclusionsRelativeToSource } from "./operations";
-import  { Event, Metadata } from './events';
+import { Event, Metadata } from './events';
 import { Property } from "./common-properties";
 
 class NodeVisitor {
@@ -135,7 +135,7 @@ export class TsParser {
             rgGlobs.push('--glob');
             rgGlobs.push(fg);
         }
-        
+
         const ripgrepArgs = ['--files-with-matches', ...rgGlobs, '--no-ignore', 'publicLog2|publicLogError2', this.sourceDir]
         try {
             const retrieved_paths = cp.execFileSync(rgPath, ripgrepArgs, { encoding: 'ascii' });
@@ -144,7 +144,7 @@ export class TsParser {
                 this.project.addSourceFileAtPathIfExists(f);
                 return f;
             });
-        // Empty catch because this fails when there are no typescript annotations which causes weird error messages
+            // Empty catch because this fails when there are no typescript annotations which causes weird error messages
         } catch (e) {
             // No-op
         }
@@ -177,11 +177,11 @@ export class TsParser {
                 } else {
                     event_name = event_name.substring(1, event_name.length - 1);
                 }
+                event_name = this.lowerCaseEvents ? event_name.toLowerCase() : event_name;
                 // Ensure there is at least an object available to assign props to
                 if (events[event_name] === undefined) {
                     events[event_name] = Object.create(null);
                 }
-                event_name = this.lowerCaseEvents ? event_name.toLowerCase() : event_name;
                 const created_event = new Event(event_name);
                 // We want the second one because public log is in the form <Event, Classification> and we care about the classification
                 const type_properties = typeArgs[1].getType().getProperties();


### PR DESCRIPTION
Many of these changes are just to have our test setup more closely mirror what we do in VS Code, the real change is in `ts-parser.ts` which shows that if we lowercase the event after applying an undefined object to the key then it's possible to create a bad telemtry report