### PR TITLE
Added intial support for parsing *.cs files and added unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vscode/telemetry-extractor",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "description": "Extracts telemetry from VS Code",
   "main": "out/index.js",
   "typings": "vscode-telemetry-extractor.d.ts",

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -151,7 +151,7 @@ export class Parser {
     private findFiles(ripgrepPattern: string, sourceDir: string) {
         const relativeExclusions = makeExclusionsRelativeToSource(sourceDir, this.excludedDirs);
         const exclusions = relativeExclusions.length === 0 || relativeExclusions[0] === '' ? [] : relativeExclusions.map(this.toRipGrepOption).flat();
-        const ripgrepArgs = ['--files-with-matches', '--glob', '*.ts', '--glob', '*.tsx', ...exclusions, '--regexp', ripgrepPattern, '--', sourceDir];
+        const ripgrepArgs = ['--files-with-matches', '--glob', '*.ts', '--glob', '*.tsx', '--glob', '*.cs', ...exclusions, '--regexp', ripgrepPattern, '--', sourceDir];
         try {
             const filePaths = cp.execFileSync(rgPath, ripgrepArgs, { encoding: 'ascii', cwd: `${sourceDir}` }); 
             return filePaths.split(/(?:\r\n|\r|\n)/g).filter(path => path && path.length > 0);

--- a/src/tests/mocha/declaration-tests.ts
+++ b/src/tests/mocha/declaration-tests.ts
@@ -9,8 +9,6 @@ import { Event, Wildcard } from "../../lib/events";
 import { Fragment } from "../../lib/fragments";
 import { getResolvedDeclaration } from '../../lib/save-declarations';
 import { ParserOptions } from "../../lib/source-spec";
-import { Console } from "console";
-
 const sourceDirs = [path.join(cwd(), 'src/tests/mocha/resources/source')];
 const excludedDirs = [path.join(sourceDirs[0], 'excluded')];
 

--- a/src/tests/mocha/declaration-tests.ts
+++ b/src/tests/mocha/declaration-tests.ts
@@ -9,6 +9,7 @@ import { Event, Wildcard } from "../../lib/events";
 import { Fragment } from "../../lib/fragments";
 import { getResolvedDeclaration } from '../../lib/save-declarations';
 import { ParserOptions } from "../../lib/source-spec";
+import { Console } from "console";
 
 const sourceDirs = [path.join(cwd(), 'src/tests/mocha/resources/source')];
 const excludedDirs = [path.join(sourceDirs[0], 'excluded')];
@@ -29,7 +30,7 @@ describe('GDPR Declaration Tests', () => {
         const parser = new Parser(sourceDirs, excludedDirs, true, false);
         const declarations = await parser.extractDeclarations();
         assert.ok(declarations);
-        assert.strictEqual(declarations.events.dataPoints.length, 4);
+        assert.strictEqual(declarations.events.dataPoints.length, 5);
         assert.strictEqual(declarations.fragments.dataPoints.length, 7);
         assert.strictEqual(declarations.commonProperties.properties.length, 2);
         assert.deepStrictEqual(declarations.commonProperties.properties[0], new Property('timestamp', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none'));
@@ -40,6 +41,7 @@ describe('GDPR Declaration Tests', () => {
         assert.strictEqual(declarations.events.dataPoints[1].name, 'EOne');
         assert.strictEqual(declarations.events.dataPoints[2].name, 'EThree');
         assert.strictEqual(declarations.events.dataPoints[3].name, 'ETwo');
+        assert.strictEqual(declarations.events.dataPoints[4].name, 'TestCSEOne');
         // We don't care what order they're read in but we want to have a consistent order so we sort them
         declarations.fragments.dataPoints = nameSort(declarations.fragments.dataPoints);
         assert.strictEqual(declarations.fragments.dataPoints[0].name, 'F0');
@@ -61,7 +63,7 @@ describe('GDPR Declaration Tests', () => {
         };
         const declarations = await getResolvedDeclaration(sourceDirs, excludedDirs, parserOptions);
         assert.ok(declarations);
-        assert.strictEqual(declarations.events.dataPoints.length, 4);
+        assert.strictEqual(declarations.events.dataPoints.length, 5);
         assert.strictEqual(declarations.commonProperties.properties.length, 2);
     });
     it('Wildcard test', async () => {

--- a/src/tests/mocha/event-tests.ts
+++ b/src/tests/mocha/event-tests.ts
@@ -25,6 +25,7 @@ describe('Events Tests', () => {
             path.join(cwd(), 'src/tests/mocha/resources/source/file1.ts'),
             path.join(cwd(), 'src/tests/mocha/resources/source/file2.ts'),
             path.join(cwd(), 'src/tests/mocha/resources/source/file3.tsx'),
+            path.join(cwd(), 'src/tests/mocha/resources/source/file4.cs'),
             path.join(cwd(), 'src/tests/mocha/resources/source/excluded/excludedFile.ts')]);
     });
     it('find files - with exclusions', () => {
@@ -35,6 +36,7 @@ describe('Events Tests', () => {
             path.join(cwd(), 'src/tests/mocha/resources/source/file1.ts'),
             path.join(cwd(), 'src/tests/mocha/resources/source/file2.ts'),
             path.join(cwd(), 'src/tests/mocha/resources/source/file3.tsx'),
+            path.join(cwd(), 'src/tests/mocha/resources/source/file4.cs'),
         ]);
     });
     it('find files - with multiple exclusions', () => {
@@ -47,7 +49,7 @@ describe('Events Tests', () => {
         const parser = new Parser([sourceDir], excludedDirs, false, false);
         //@ts-ignore
         const events = parser.findEvents(sourceDir);
-        assert.strictEqual(events.dataPoints.length, 4);
+        assert.strictEqual(events.dataPoints.length, 5);
         events.dataPoints = nameSort(events.dataPoints);
         assert.strictEqual(events.dataPoints[0].name, 'EFour');
     });
@@ -73,7 +75,7 @@ describe('Resolve Tests', () => {
         const declarations = await getResolvedDeclaration([sourceDir], excludedDirs, parserOptions);
         assert.ok(declarations.events);
         declarations.events.dataPoints = nameSort(declarations.events.dataPoints);
-        assert.strictEqual(declarations.events.dataPoints.length,4);
+        assert.strictEqual(declarations.events.dataPoints.length,5);
         assert.ok(declarations.commonProperties);
         assert.strictEqual(declarations.commonProperties.properties.length, 2);
         assert.deepStrictEqual(declarations.commonProperties.properties[0], new Property('timestamp', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none'));

--- a/src/tests/mocha/event-tests.ts
+++ b/src/tests/mocha/event-tests.ts
@@ -10,6 +10,7 @@ import { getResolvedDeclaration } from "../../lib/save-declarations";
 import { Property } from "../../lib/common-properties";
 import { patchDebugEvents } from "../../lib/debug-patch";
 import { ParserOptions } from "../../lib/source-spec";
+import { Metadata } from "../../lib/events";
 
 const sourceDir = path.join(cwd(), 'src/tests/mocha/resources/source');
 const excludedDirs = [path.join(sourceDir, 'excluded')];
@@ -88,5 +89,13 @@ describe('Resolve Tests', () => {
         assert.deepStrictEqual(e1Properties[2], new Property('property_EOneP3', 'SystemMetaData', 'FeatureInsight', '1.57.0', "lramos15", "Test event", 'none'));
         assert.deepStrictEqual(e1Properties[3], new Property('measurement_EOneM1', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none', true));
         assert.deepStrictEqual(e1Properties[4], new Property('measurement_EOneM<NUMBER>', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none', true));
-    });
+        const testCSEOneProperties = declarations.events.dataPoints[4].properties;
+        assert.deepStrictEqual(testCSEOneProperties[0], new Metadata('owner', 'jonathanyi'));
+        assert.deepStrictEqual(testCSEOneProperties[1], new Metadata('comment', 'Output to Console log test event.'));
+        assert.deepStrictEqual(testCSEOneProperties[2], new Property('property_ECSharpP1', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, "NA"));
+        assert.deepStrictEqual(testCSEOneProperties[3], new Property('property_ECSharpP2', 'CallstackOrException', 'PerformanceAndHealth', undefined, undefined, undefined, "NA"));
+        assert.deepStrictEqual(testCSEOneProperties[4], new Property('property_ECSharpP3', 'SystemMetaData', 'FeatureInsight', "1.57.0", "jonathanjyi", "Test event", "none", undefined));
+        assert.deepStrictEqual(testCSEOneProperties[5], new Property('measurement_ECSharpM1', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none', true));
+        assert.deepStrictEqual(testCSEOneProperties[6], new Property('measurement_ECSharpM<NUMBER>', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none', true));
+    })
 });

--- a/src/tests/mocha/resources/source/file4.cs
+++ b/src/tests/mocha/resources/source/file4.cs
@@ -7,10 +7,10 @@ public class Program
     {
       /* __GDPR__
         "TestCSEOne" : {
-          "owner": "jonathanjyi",
+          "owner": "jonathanyi",
           "comment": "Output to Console log test event.",
-          "property_ECSharpP1": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-          "property_ECSharpP2": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },
+          "property_ECSharpP1": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "endpoint": "NA" },
+          "property_ECSharpP2": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth", "endpoint": "NA" },
           "property_ECSharpP3": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "expiration": "1.57.0", "owner": "jonathanjyi", "comment": "Test event" },
           "measurement_ECSharpM1": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
           "measurement_ECSharpM<NUMBER>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }

--- a/src/tests/mocha/resources/source/file4.cs
+++ b/src/tests/mocha/resources/source/file4.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+public class Program
+{
+    static async Task Main(string[] args)
+    {
+      /* __GDPR__
+        "TestCSEOne" : {
+          "owner": "jonathanjyi",
+          "comment": "Output to Console log test event.",
+          "property_ECSharpP1": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "property_ECSharpP2": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },
+          "property_ECSharpP3": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "expiration": "1.57.0", "owner": "jonathanjyi", "comment": "Test event" },
+          "measurement_ECSharpM1": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
+          "measurement_ECSharpM<NUMBER>": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true }
+        }
+      */
+      Console.WriteLine("CSEOne");
+    }
+}


### PR DESCRIPTION
Added initial support for parsing C# files by adding the '.cs' extension to the list of file extensions to glob in the parser. Also extended existing unit testing to support the new file extension.