### PR TITLE
Add support for table info in GDPR comments

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ const tseslint = require('typescript-eslint');
 
 module.exports = tseslint.config(
   {
-    ignores: ['out/**', 'src/tests/mocha/resources/**'],
+    ignores: ['out/**', 'src/tests/mocha/resources/**', 'src/tests/mocha/tableResources/**'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommended,
@@ -11,8 +11,12 @@ module.exports = tseslint.config(
     files: ['eslint.config.js'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
-      "@typescript-eslint/no-namespace": "off",
       'no-undef': 'off',
     },
   },
+  {
+    rules: {
+      '@typescript-eslint/no-namespace': 'off',
+    },
+  }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,6 +11,7 @@ module.exports = tseslint.config(
     files: ['eslint.config.js'],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
+      "@typescript-eslint/no-namespace": "off",
       'no-undef': 'off',
     },
   },

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -28,7 +28,7 @@ export const optionDefinitions = [
     { name: 'silenceOutput', type: Boolean, description: 'Silences all progress messages.', defaultValue: false },
     { name: 'lowerCaseEvents', alias: 'l', type: Boolean, defaultValue: false },
     { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
-    { name: 'kusto', alias: 'k', type: Boolean, description: 'Outputs Kusto table information. Only valid together with the file name option.', defaultValue: false }
+    { name: 'tableInfo', alias: 't', type: Boolean, description: 'Outputs Kusto table information. Only valid together with the file name option.', defaultValue: false }
 ];
 
 export const options = resolveDirectories(commandLineArgs(optionDefinitions, { partial: true }));

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -28,7 +28,7 @@ export const optionDefinitions = [
     { name: 'silenceOutput', type: Boolean, description: 'Silences all progress messages.', defaultValue: false },
     { name: 'lowerCaseEvents', alias: 'l', type: Boolean, defaultValue: false },
     { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
-    { name: 'tableInfo', alias: 't', type: Boolean, description: 'Outputs Kusto table information. Only valid together with the file name option.', defaultValue: false }
+    { name: 'tableInfo', alias: 't', type: Boolean, description: 'Outputs Kusto table information. If no filename is specified the default file name with -tableInfo is used.', defaultValue: false }
 ];
 
 export const options = resolveDirectories(commandLineArgs(optionDefinitions, { partial: true }));

--- a/src/cli-options.ts
+++ b/src/cli-options.ts
@@ -27,7 +27,8 @@ export const optionDefinitions = [
     { name: 'applyEndpoints', alias: 'e', type: Boolean, defaultValue: false },
     { name: 'silenceOutput', type: Boolean, description: 'Silences all progress messages.', defaultValue: false },
     { name: 'lowerCaseEvents', alias: 'l', type: Boolean, defaultValue: false },
-    { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false }
+    { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
+    { name: 'kusto', alias: 'k', type: Boolean, description: 'Outputs Kusto table information. Only valid together with the file name option.', defaultValue: false }
 ];
 
 export const options = resolveDirectories(commandLineArgs(optionDefinitions, { partial: true }));

--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -7,6 +7,7 @@ import { cwd } from 'process';
 import { writeToFile, extractAndResolveDeclarations } from './lib/save-declarations';
 import { convertConfigToSourceSpecs, ParserOptions, SourceSpec } from './lib/source-spec';
 import { logMessage } from './lib/logger';
+import type { OutputtedDeclarations } from './lib/declarations';
 
 if (options.config) {
     const sourceSpecs = convertConfigToSourceSpecs(options.config);
@@ -36,7 +37,13 @@ if (options.config) {
     };
     extractAndResolveDeclarations([sourceSpec]).then((declarations) => {
         if (options.outputDir) {
-            writeToFile(options.outputDir, declarations, options.fileName || 'declarations-resolved', !options.silent);
+            const tableInfos = declarations.tableInfos;
+            const gdprDeclarations: Partial<OutputtedDeclarations> = { ...declarations };
+            delete gdprDeclarations.tableInfos;
+            writeToFile(options.outputDir, gdprDeclarations, options.fileName || 'declarations-resolved', !options.silent);
+            if (options.tableInfo) {
+                writeToFile(options.outputDir, tableInfos, options.fileName ? options.fileName + '-tableInfo' : 'tableInfo', !options.silent);
+            }
         } else {
             console.log(JSON.stringify(declarations));
         }

--- a/src/lib/common-properties.ts
+++ b/src/lib/common-properties.ts
@@ -62,7 +62,7 @@ export type ColumnInfo = {
 }
 
 export namespace ColumnInfo {
-    export function is(obj: any): obj is ColumnInfo {
+    export function is(obj: unknown): obj is ColumnInfo {
         const candidate = obj as ColumnInfo;
         return !!candidate &&
             (candidate.name === undefined || typeof candidate.name === 'string') &&

--- a/src/lib/common-properties.ts
+++ b/src/lib/common-properties.ts
@@ -9,6 +9,67 @@ export class CommonProperties {
     }
 }
 
+export type ColumnType =
+    'bool' |
+    'int' |
+    'long' |
+    'real' |
+    'decimal' |
+    'dynamic' |
+    'guid' |
+    'string' |
+    'datetime' |
+    'timespan';
+
+export namespace ColumnType {
+    export function fromString(type: string): ColumnType | undefined{
+        switch (type.toLowerCase()) {
+            case 'bool':
+            case 'boolean':
+                return 'bool';
+            case 'int':
+                return 'int';
+            case 'long':
+                return 'long';
+            case 'real':
+            case 'double':
+                return 'real';
+            case 'decimal':
+                return 'decimal';
+            case 'dynamic':
+                return 'dynamic';
+            case 'guid':
+            case 'uuid':
+            case 'uniqueid':
+                return 'guid';
+            case 'string':
+                return 'string';
+            case 'datetime':
+            case 'date':
+                return 'datetime';
+            case 'timespan':
+            case 'time':
+                return 'timespan';
+            default:
+                return undefined;
+        }
+    }
+}
+
+export type ColumnInfo = {
+    name?: string;
+    type: ColumnType;
+}
+
+export namespace ColumnInfo {
+    export function is(obj: any): obj is ColumnInfo {
+        const candidate = obj as ColumnInfo;
+        return !!candidate &&
+            (candidate.name === undefined || typeof candidate.name === 'string') &&
+            typeof candidate.type === 'string' && ColumnType.fromString(candidate.type) !== undefined;
+    }
+}
+
 export class Property implements IProperty {
     public name: string;
     public classification: string;
@@ -18,16 +79,21 @@ export class Property implements IProperty {
     public expiration?: string;
     public owner?: string;
     public comment?: string;
-    
+
+    // The name and type of the property if mirrored into a flat table in Kusto.
+    // Needs to be removed when generating the patch for the GDPR catalog as
+    // flat table properties are not allowed in the catalog.
+    public column?: ColumnInfo;
+
     constructor (
-        name: string, 
+        name: string,
         classification: string,
-        purpose: string, 
+        purpose: string,
         expiration?: string,
         owner?: string,
         comment?: string,
-        endpoint?: string, 
-        isMeasurement?: boolean
+        endpoint?: string,
+        isMeasurement?: boolean,
     ) {
         this.name = name;
         this.classification = classification;

--- a/src/lib/declarations.ts
+++ b/src/lib/declarations.ts
@@ -3,7 +3,7 @@
 import { Fragments } from "./fragments";
 import { Events, Include, Inline } from "./events";
 import { CommonProperties, Property } from "./common-properties";
-import type { Events as OutputEvents, CommonProperties as OutputCommonProperties } from "../../vscode-telemetry-extractor";
+import type { Events as OutputEvents, CommonProperties as OutputCommonProperties , TableInfo as OutputTableInfo } from "../../vscode-telemetry-extractor";
 
 export interface Declarations {
     fragments: Fragments;
@@ -15,6 +15,7 @@ export interface Declarations {
 export interface OutputtedDeclarations {
     events: OutputEvents;
     commonProperties: OutputCommonProperties;
+    tableInfos: OutputTableInfo[];
 }
 
 function resolveIncludes(target: Events | Fragments, fragments: Fragments) {

--- a/src/lib/declarations.ts
+++ b/src/lib/declarations.ts
@@ -15,7 +15,7 @@ export interface Declarations {
 export interface OutputtedDeclarations {
     events: OutputEvents;
     commonProperties: OutputCommonProperties;
-    tableInfos: OutputTableInfo[];
+    tableInfos: { [key: string]: OutputTableInfo };
 }
 
 function resolveIncludes(target: Events | Fragments, fragments: Fragments) {

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -11,14 +11,45 @@ export class Events implements ITelemetryData {
     }
 }
 
+export type TableInfo = {
+    name: string;
+    commonProperties: 'standard';
+    backfill: boolean | string;
+}
+export namespace TableInfo {
+    export function fromObject(obj: unknown): TableInfo | undefined {
+        if (typeof obj !== 'object' || obj === null) {
+            return undefined;
+        }
+        const candidate: Partial<TableInfo> = obj as TableInfo;
+        if (typeof candidate.name !== 'string') {
+            return undefined;
+        }
+        const result: TableInfo = {
+            name: candidate.name,
+            commonProperties: 'standard',
+            backfill: false
+        };
+        if (candidate.commonProperties === 'standard') {
+            result.commonProperties = 'standard';
+        }
+        if (typeof candidate.backfill === 'boolean' || typeof candidate.backfill === 'string') {
+            result.backfill = candidate.backfill;
+        }
+        return result;
+    }
+}
+
 export class Event implements ITelemetryDataPoint {
     public name: string;
     // It gets a little more complicated here as events can have a bunch of different things
     public properties: Array<Property | Metadata | Include | Inline | Wildcard>;
+    public tableInfo?: TableInfo;
     constructor (name: string) {
         this.name =  name;
         this.properties = [];
-    } 
+        this.tableInfo = undefined;
+    }
 }
 
 export class Include implements IInclude {

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -29,6 +29,7 @@ export namespace TableInfo {
             name: candidate.name,
             commonProperties: 'standard',
             backfill: false
+
         };
         if (candidate.commonProperties === 'standard') {
             result.commonProperties = 'standard';

--- a/src/lib/object-converter.ts
+++ b/src/lib/object-converter.ts
@@ -1,25 +1,30 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 import { Declarations, OutputtedDeclarations } from "./declarations";
-import { Property } from "./common-properties";
-import { Metadata, Wildcard } from "./events";
+import { ColumnType, Property, ColumnInfo } from "./common-properties";
+import { Metadata, Wildcard, TableInfo as JsonTableInfo } from "./events";
 import * as keywords from './keywords';
 
 // Converts the declarations array to an object format for easy readability.
 
+type TableInfo = OutputtedDeclarations['tableInfos'][number];
+type BagInfo = TableInfo['columns'][number]['bag'];
+
 export async function transformOutput(output: Declarations): Promise<OutputtedDeclarations> {
     // If there's no events or common properties, we emit a null object
     if (output.events.dataPoints.length === 0 && output.commonProperties.properties.length === 0) {
-        return { events: Object.create(null), commonProperties: Object.create(null) };
+        return { events: Object.create(null), commonProperties: Object.create(null), tableInfos: [] };
     }
     const newEvents = Object.create(null);
     const oldEvents = output.events.dataPoints;
+    const tableInfos: TableInfo[] = [];
     for (const event of oldEvents) {
         // Check if event.name ends with a number, if so throw an error because we don't support event names which end with numbers
         if (/\d$/.test(event.name)) {
             throw new Error(`Event name ${event.name} ends with a number. Event names cannot end with numbers.`);
         }
         newEvents[event.name] = Object.create(null);
+        const tableInfo: TableInfo | undefined = event.tableInfo ? { ...event.tableInfo, columns: [] } : undefined;
         //We know there won't be anymore includes or inlines because we have resolved them
         for (const property of event.properties as Array<Property | Wildcard | Metadata>) {
             if (property instanceof Wildcard) {
@@ -66,10 +71,17 @@ export async function transformOutput(output: Declarations): Promise<OutputtedDe
                 if (property.isMeasurement) {
                     newEvents[event.name][propetyNameChanger(property.name)]['isMeasurement'] = property.isMeasurement;
                 }
+                if (tableInfo !== undefined && property.column) {
+                    const name = property.column.name ?? property.name;
+                    tableInfo.columns.push({ name, type: property.column.type, bag: { name: property.name, store: property.isMeasurement === true ? 'Measures' : 'Properties' } });
+                }
             } else {
                 // Comments, expiration, and owner metadata are handled here
                 newEvents[event.name][propetyNameChanger(property.name)] = property.value;
             }
+        }
+        if (tableInfo !== undefined) {
+            tableInfos.push(tableInfo);
         }
     }
     const newCommonProperties = Object.create(null);
@@ -89,8 +101,59 @@ export async function transformOutput(output: Declarations): Promise<OutputtedDe
             newCommonProperties[propetyNameChanger(property.name)]['isMeasurement'] = property.isMeasurement;
         }
     }
-    return { events: newEvents, commonProperties: newCommonProperties };
+    return { events: newEvents, commonProperties: newCommonProperties, tableInfos };
 }
+
+type TypeScriptPropertyDeclaration = {
+    name?: string;
+    isMeasurement?: boolean;
+    type?: string;
+    column?: { name?: string; type?: string }
+}
+type TypeScriptEventDeclaration = {
+    $tableInfo?: unknown;
+    [name: string]: TypeScriptPropertyDeclaration | unknown;
+};
+
+export function transformTypeScriptDeclaration(declaration: TypeScriptEventDeclaration): { declaration: object, tableInfo: TableInfo | undefined} {
+    // The property names in the TS events are already all lowercased.
+    const tableInfoProperty = declaration['$tableinfo'];
+    let tableInfo: TableInfo | undefined = undefined;
+    if (tableInfoProperty !== undefined) {
+        delete declaration['$tableinfo'];
+        const json = JsonTableInfo.fromObject(tableInfoProperty);
+        if (json !== undefined) {
+            tableInfo = { name: json.name, commonProperties: json.commonProperties, backfill: json.backfill, columns: [] };
+        }
+    }
+    for (const name of Object.keys(declaration)) {
+        if (name === '$tableinfo') {
+            continue;
+        }
+        const property = declaration[name] as TypeScriptPropertyDeclaration;
+        if (!property || typeof property !== 'object') {
+            continue;
+        }
+        if (tableInfo !== undefined) {
+            if (property.column !== undefined) {
+                if (ColumnInfo.is(property.column)) {
+                    const bag: BagInfo = { store: property.isMeasurement === true ? 'Measures' : 'Properties', name: name };
+                    tableInfo.columns.push({ name: property.column.name ?? name, type: property.column.type, bag });
+                }
+            } else if (typeof property.type === 'string') {
+                const columnType = ColumnType.fromString(property.type);
+                if (columnType) {
+                    const bag: BagInfo = { store: property.isMeasurement === true ? 'Measures' : 'Properties', name: name };
+                    tableInfo.columns.push({ name: name, type: columnType, bag });
+                }
+            }
+        }
+        delete property.type;
+        delete property.column;
+    }
+    return { declaration, tableInfo };
+}
+
 
 function propetyNameChanger(name: string) {
     name = name.toLowerCase();

--- a/src/lib/object-converter.ts
+++ b/src/lib/object-converter.ts
@@ -73,7 +73,7 @@ export async function transformOutput(output: Declarations): Promise<OutputtedDe
                 }
                 if (tableInfo !== undefined && property.column) {
                     const name = property.column.name ?? property.name;
-                    tableInfo.columns.push({ name, type: property.column.type, bag: { name: property.name, store: property.isMeasurement === true ? 'Measures' : 'Properties' } });
+                    tableInfo.columns.push({ name, type: property.column.type, bag: { name: property.name.toLowerCase(), store: property.isMeasurement === true ? 'Measures' : 'Properties' } });
                 }
             } else {
                 // Comments, expiration, and owner metadata are handled here

--- a/src/lib/object-converter.ts
+++ b/src/lib/object-converter.ts
@@ -140,8 +140,11 @@ export function transformTypeScriptDeclaration(declaration: TypeScriptEventDecla
         if (tableInfo !== undefined) {
             if (property.column !== undefined) {
                 if (ColumnInfo.is(property.column)) {
-                    const bag: BagInfo = { store: property.isMeasurement === true ? 'Measures' : 'Properties', name: name };
-                    tableInfo.columns.push({ name: property.column.name ?? name, type: property.column.type, bag });
+                    const type = ColumnType.fromString(property.column.type);
+                    if (type !== undefined) {
+                        const bag: BagInfo = { store: property.isMeasurement === true ? 'Measures' : 'Properties', name: name };
+                        tableInfo.columns.push({ name: property.column.name ?? name, type: type, bag });
+                    }
                 }
             } else if (typeof property.type === 'string') {
                 const columnType = ColumnType.fromString(property.type);

--- a/src/lib/object-converter.ts
+++ b/src/lib/object-converter.ts
@@ -7,17 +7,17 @@ import * as keywords from './keywords';
 
 // Converts the declarations array to an object format for easy readability.
 
-type TableInfo = OutputtedDeclarations['tableInfos'][number];
+type TableInfo = OutputtedDeclarations['tableInfos'][string];
 type BagInfo = TableInfo['columns'][number]['bag'];
 
 export async function transformOutput(output: Declarations): Promise<OutputtedDeclarations> {
     // If there's no events or common properties, we emit a null object
     if (output.events.dataPoints.length === 0 && output.commonProperties.properties.length === 0) {
-        return { events: Object.create(null), commonProperties: Object.create(null), tableInfos: [] };
+        return { events: Object.create(null), commonProperties: Object.create(null), tableInfos: {} };
     }
     const newEvents = Object.create(null);
     const oldEvents = output.events.dataPoints;
-    const tableInfos: TableInfo[] = [];
+    const tableInfos: { [key: string]: TableInfo } = {};
     for (const event of oldEvents) {
         // Check if event.name ends with a number, if so throw an error because we don't support event names which end with numbers
         if (/\d$/.test(event.name)) {
@@ -25,6 +25,9 @@ export async function transformOutput(output: Declarations): Promise<OutputtedDe
         }
         newEvents[event.name] = Object.create(null);
         const tableInfo: TableInfo | undefined = event.tableInfo ? { ...event.tableInfo, columns: [] } : undefined;
+        if (tableInfo) {
+            tableInfos[tableInfo.name] = tableInfo;
+        }
         //We know there won't be anymore includes or inlines because we have resolved them
         for (const property of event.properties as Array<Property | Wildcard | Metadata>) {
             if (property instanceof Wildcard) {
@@ -81,7 +84,7 @@ export async function transformOutput(output: Declarations): Promise<OutputtedDe
             }
         }
         if (tableInfo !== undefined) {
-            tableInfos.push(tableInfo);
+            tableInfos[tableInfo.name] = tableInfo;
         }
     }
     const newCommonProperties = Object.create(null);

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -137,6 +137,10 @@ export function mergeWildcards(wildcard: any[], target: Event | Fragment, applyE
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function populateProperties(properties: any, target: Event | Fragment, applyEndpoints = false) {
     for (const propertyName in properties) {
+        // Skip the `$table` property since it is an artificial property for the flat table support.
+        if (propertyName === '$table') {
+            continue;
+        }
         const currentProperty = properties[propertyName];
         if (propertyName === keywords.include) {
             target.properties.push(new Include(currentProperty));

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -167,7 +167,10 @@ export function populateProperties(properties: any, target: Event | Fragment, ap
                     prop.column = { type: columnType };
                 }
             } else if (ColumnInfo.is(currentProperty.column)) {
-                prop.column = { ...currentProperty.column };
+                const columnType = ColumnType.fromString(currentProperty.column.type);
+                if (columnType) {
+                    prop.column = { name: currentProperty.column.name, type: columnType };
+                }
             }
             target.properties.push(prop);
         }

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -137,8 +137,8 @@ export function mergeWildcards(wildcard: any[], target: Event | Fragment, applyE
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function populateProperties(properties: any, target: Event | Fragment, applyEndpoints = false) {
     for (const propertyName in properties) {
-        // Skip the `$table` property since it is an artificial property for the flat table support.
-        if (propertyName === '$table') {
+        // Skip the `$tableInfo` property since it is an artificial property for the flat table support.
+        if (propertyName === '$tableInfo') {
             continue;
         }
         const currentProperty = properties[propertyName];

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 import { Fragments, Fragment } from "./fragments";
 import { Events, Event, Include, Inline, Wildcard, WildcardEntry, Metadata } from "./events";
-import { Property } from "./common-properties";
+import { ColumnType, ColumnInfo, Property } from "./common-properties";
 import * as keywords from './keywords';
 import * as path from 'path';
 
@@ -98,7 +98,7 @@ function stableSerialize(value: unknown): string {
     return JSON.stringify(value);
 }
 
-// Searches the object for an event or fragment of the specific name 
+// Searches the object for an event or fragment of the specific name
 // If found returns, if not found creates it, places it in the array, and then returns
 export function findOrCreate(searchTarget: Events | Fragments, name: string) {
     let found = searchTarget.dataPoints.find((item) => {
@@ -156,6 +156,14 @@ export function populateProperties(properties: any, target: Event | Fragment, ap
             }
             if (currentProperty.isMeasurement) {
                 prop.isMeasurement = currentProperty.isMeasurement;
+            }
+            if (typeof currentProperty.type === 'string') {
+                const columnType = ColumnType.fromString(currentProperty.type);
+                if (columnType) {
+                    prop.column = { type: columnType };
+                }
+            } else if (ColumnInfo.is(currentProperty.column)) {
+                prop.column = { ...currentProperty.column };
             }
             target.properties.push(prop);
         }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -154,8 +154,8 @@ export class Parser {
 
                 eventSignatures.set(eventName, currentSignature);
                 const event = findOrCreate(eventDeclarations, eventName);
-                if (event instanceof Event && eventProperties['$table'] !== undefined) {
-                    const tableInfo: TableInfo | undefined = TableInfo.fromObject(eventProperties['$table']);
+                if (event instanceof Event && eventProperties['$tableInfo'] !== undefined) {
+                    const tableInfo: TableInfo | undefined = TableInfo.fromObject(eventProperties['$tableInfo']);
                     if (tableInfo) {
                         event.tableInfo = tableInfo;
                     }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs';
 // Not importing 'process' as tsc claims `process.exitCode` is read-only when it actually is not.
 import { Fragments } from './fragments';
 import { Property, CommonProperties } from './common-properties';
-import { Events } from './events';
+import { Events, Event, TableInfo } from './events';
 import { Declarations } from './declarations';
 import { merge, findOrCreate, populateProperties, makeExclusionsRelativeToSource } from './operations';
 
@@ -154,6 +154,12 @@ export class Parser {
 
                 eventSignatures.set(eventName, currentSignature);
                 const event = findOrCreate(eventDeclarations, eventName);
+                if (event instanceof Event && eventProperties['$table'] !== undefined) {
+                    const tableInfo: TableInfo | undefined = TableInfo.fromObject(eventProperties['$table']);
+                    if (tableInfo) {
+                        event.tableInfo = tableInfo;
+                    }
+                }
                 // Get the propeties which the event possesses
                 populateProperties(eventProperties, event, this.applyEndpoints);
             } catch (error) {

--- a/src/lib/save-declarations.ts
+++ b/src/lib/save-declarations.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { Parser } from './parser';
 import * as fileWriter from './file-writer';
 import { resolveDeclarations, OutputtedDeclarations, Declarations } from './declarations';
-import { transformOutput } from './object-converter';
+import { transformOutput, transformTypeScriptDeclaration } from './object-converter';
 import { Events } from './events';
 import { CommonProperties } from './common-properties';
 import { TsParser } from './ts-parser';
@@ -152,7 +152,11 @@ export async function extractAndResolveDeclarations(sourceSpecs: Array<SourceSpe
             if (formattedDeclarations.events === undefined) {
                 formattedDeclarations.events = Object.create(null);
             }
-            formattedDeclarations.events[dec] = allTypeScriptDeclarations[dec];
+            const transformed = transformTypeScriptDeclaration(allTypeScriptDeclarations[dec]);
+            formattedDeclarations.events[dec] = transformed.declaration as OutputtedDeclarations['events'][number];
+            if (transformed.tableInfo) {
+                formattedDeclarations.tableInfos.push(transformed.tableInfo);
+            }
         }
         const hasPropertyValidationErrors = validateOutputtedDeclarations(formattedDeclarations);
         if (hasDuplicateEventConflicts || hasPropertyValidationErrors || process.exitCode === 1) {
@@ -164,3 +168,5 @@ export async function extractAndResolveDeclarations(sourceSpecs: Array<SourceSpe
         return Promise.reject(error);
     }
 }
+
+

--- a/src/lib/save-declarations.ts
+++ b/src/lib/save-declarations.ts
@@ -153,9 +153,10 @@ export async function extractAndResolveDeclarations(sourceSpecs: Array<SourceSpe
                 formattedDeclarations.events = Object.create(null);
             }
             const transformed = transformTypeScriptDeclaration(allTypeScriptDeclarations[dec]);
-            formattedDeclarations.events[dec] = transformed.declaration as OutputtedDeclarations['events'][number];
+            formattedDeclarations.events[dec] = transformed.declaration as OutputtedDeclarations['events'][string];
             if (transformed.tableInfo) {
-                formattedDeclarations.tableInfos.push(transformed.tableInfo);
+                const tableInfo = transformed.tableInfo;
+                formattedDeclarations.tableInfos[tableInfo.name] = tableInfo;
             }
         }
         const hasPropertyValidationErrors = validateOutputtedDeclarations(formattedDeclarations);

--- a/src/lib/ts-parser.ts
+++ b/src/lib/ts-parser.ts
@@ -110,7 +110,7 @@ class NodeVisitor {
 
     private visitNode(currentNode: Symbol, previousNode?: Symbol) {
         let type = currentNode.getTypeAtLocation(this.pl_node);
-        // If we mark a property as optional then it is nullable, however we want all properties 
+        // If we mark a property as optional then it is nullable, however we want all properties
         // So we want its non nullable type tl;dr this chops off the | undefined
         if (type.isNullable()) {
             type = type.getNonNullableType();
@@ -156,7 +156,7 @@ class NodeVisitor {
 
     private visitMetadataNode(currentNode: Symbol) {
         let type = currentNode.getTypeAtLocation(this.pl_node);
-        // If we mark a property as optional then it is nullable, however we want all properties 
+        // If we mark a property as optional then it is nullable, however we want all properties
         // So we want its non nullable type tl;dr this chops off the | undefined
         if (type.isNullable()) {
             type = type.getNonNullableType();

--- a/src/lib/ts-parser.ts
+++ b/src/lib/ts-parser.ts
@@ -322,7 +322,7 @@ export class TsParser {
                 this.addEventDefinition(event_name, this.stableSerialize(events[event_name]), `${pl.getSourceFile().getFilePath()}:${pl.getStartLineNumber()}`);
                 const eventProperties = typeArgs[0].getType().getProperties();
                 // Find all eventProperties that have a number or boolean type
-                eventProperties.clsforEach((prop) => {
+                eventProperties.forEach((prop) => {
                     const propName = prop.getEscapedName().toLowerCase();
                     const valueDeclaration = prop.getValueDeclaration();
                     if (valueDeclaration === undefined) {

--- a/src/lib/ts-parser.ts
+++ b/src/lib/ts-parser.ts
@@ -135,10 +135,23 @@ class NodeVisitor {
             }
             return;
         }
-        const properties = type.getProperties();
-        properties.forEach((prop) => {
-            this.visitNode(prop, currentNode);
-        });
+        const nodeName = currentNode.getEscapedName();
+        if (nodeName !== 'column') {
+            const properties = type.getProperties();
+            properties.forEach((prop) => {
+                this.visitNode(prop, currentNode);
+            });
+        } else {
+            const properties = type.getProperties();
+            const value = Object.create(null);
+            properties.forEach((prop) => {
+                const propType = prop.getTypeAtLocation(this.pl_node);
+                if (propType.isStringLiteral()) {
+                    value[prop.getEscapedName()] = propType.getText().substring(1, propType.getText().length - 1);
+                }
+            });
+            this.resolved_property['column'] = value;
+        }
         // 95% of the time there is only one property in this array but inlines allow
         // for the number of properties found to be unpredictable so we must return an array
         if (this.inline && this.prop_name === this.original_prop_name) {

--- a/src/lib/ts-parser.ts
+++ b/src/lib/ts-parser.ts
@@ -171,6 +171,9 @@ class NodeVisitor {
     }
 
     public resolveProperties(currentNode: Symbol): Array<Property | Metadata> {
+        // @lramos15 Actually this.properties is of type any[] and the property data pushing into
+        // the array is not an instance of Property.
+
         // It could be a complex node with nested types or a simple node with a string literal
         // representing some kind of metadata, so we try both visitors.
         this.visitMetadataNode(currentNode);
@@ -300,7 +303,18 @@ export class TsParser {
                 type_properties.forEach((prop) => {
                     const propName = prop.getEscapedName().toLowerCase();
                     const node_visitor = new NodeVisitor(pl, propName, this.applyEndpoints);
-                    created_event.properties = created_event.properties.concat(node_visitor.resolveProperties(prop));
+                    const resolved_properties = node_visitor.resolveProperties(prop);
+                    for (const rp of resolved_properties) {
+                        if (!(rp instanceof Metadata)) {
+                            // This cast is necessary since rp is not of type Property although
+                            // the resolveProperties claims it to be.
+                            const propInfo = (rp as unknown as { [key: string]: object })[propName];
+                            if (propInfo !== undefined) {
+                                this.captureOriginalPropNameForColumnInformation(prop.getEscapedName(), propInfo);
+                            }
+                        }
+                    }
+                    created_event.properties = created_event.properties.concat(resolved_properties);
                 });
                 created_event.properties.forEach((prop) => {
                     Object.assign(events[event_name], prop);
@@ -308,7 +322,7 @@ export class TsParser {
                 this.addEventDefinition(event_name, this.stableSerialize(events[event_name]), `${pl.getSourceFile().getFilePath()}:${pl.getStartLineNumber()}`);
                 const eventProperties = typeArgs[0].getType().getProperties();
                 // Find all eventProperties that have a number or boolean type
-                eventProperties.forEach((prop) => {
+                eventProperties.clsforEach((prop) => {
                     const propName = prop.getEscapedName().toLowerCase();
                     const valueDeclaration = prop.getValueDeclaration();
                     if (valueDeclaration === undefined) {
@@ -343,5 +357,14 @@ export class TsParser {
             }
         });
         return events;
+    }
+
+    private captureOriginalPropNameForColumnInformation(propName: string, property: { type?: string; column?: { name?: string; type: string } }) {
+        if (property.column && property.column.name === undefined) {
+            property.column.name = propName;
+        } else if (typeof property.type === 'string') {
+            property.column = { name: propName, type: property.type };
+            delete property.type;
+        }
     }
 }

--- a/src/tests/mocha/common-property-test.ts
+++ b/src/tests/mocha/common-property-test.ts
@@ -5,7 +5,7 @@ import * as assert from 'assert';
 import * as assertHelper from './assert-helper';
 import * as path from 'path';
 import { cwd } from "process";
-import { Property } from "../../lib/common-properties";
+import { Property, ColumnType, ColumnInfo } from "../../lib/common-properties";
 
 const sourceDir = path.join(cwd(), 'src/tests/mocha/resources/');
 const excludeDirs = [path.join(sourceDir, 'source'), path.join(sourceDir, 'source-1')];
@@ -26,3 +26,97 @@ describe('GDPR common property extraction', () => {
     assert.deepStrictEqual(commonProperties.properties[1], new Property('machineid', 'EndUserPseudonymizedInformation', 'FeatureInsight', undefined, undefined, undefined, 'MacAddressHash'));
   });
 });
+
+describe('ColumnType', () => {
+  it('parses canonical type names', () => {
+    const canonicalTypes: ColumnType[] = ['bool', 'int', 'long', 'real', 'decimal', 'dynamic', 'guid', 'string', 'datetime', 'timespan'];
+    for (const type of canonicalTypes) {
+      assert.strictEqual(ColumnType.fromString(type), type);
+    }
+  });
+
+  it('parses alias type names to canonical form', () => {
+    assert.strictEqual(ColumnType.fromString('boolean'), 'bool');
+    assert.strictEqual(ColumnType.fromString('double'), 'real');
+    assert.strictEqual(ColumnType.fromString('uuid'), 'guid');
+    assert.strictEqual(ColumnType.fromString('uniqueid'), 'guid');
+    assert.strictEqual(ColumnType.fromString('date'), 'datetime');
+    assert.strictEqual(ColumnType.fromString('time'), 'timespan');
+  });
+
+  it('is case-insensitive', () => {
+    assert.strictEqual(ColumnType.fromString('String'), 'string');
+    assert.strictEqual(ColumnType.fromString('BOOL'), 'bool');
+    assert.strictEqual(ColumnType.fromString('DateTime'), 'datetime');
+    assert.strictEqual(ColumnType.fromString('BOOLEAN'), 'bool');
+    assert.strictEqual(ColumnType.fromString('Double'), 'real');
+  });
+
+  it('returns undefined for unknown types', () => {
+    assert.strictEqual(ColumnType.fromString('unknown'), undefined);
+    assert.strictEqual(ColumnType.fromString('varchar'), undefined);
+    assert.strictEqual(ColumnType.fromString(''), undefined);
+    assert.strictEqual(ColumnType.fromString('number'), undefined);
+  });
+});
+
+describe('ColumnInfo', () => {
+  it('validates a complete column info with name and type', () => {
+    assert.strictEqual(ColumnInfo.is({ name: 'Duration', type: 'real' }), true);
+    assert.strictEqual(ColumnInfo.is({ name: 'Outcome', type: 'string' }), true);
+  });
+
+  it('validates column info without name (name is optional)', () => {
+    assert.strictEqual(ColumnInfo.is({ type: 'long' }), true);
+    assert.strictEqual(ColumnInfo.is({ type: 'bool' }), true);
+  });
+
+  it('accepts alias type names', () => {
+    assert.strictEqual(ColumnInfo.is({ name: 'Active', type: 'boolean' }), true);
+    assert.strictEqual(ColumnInfo.is({ name: 'Latency', type: 'double' }), true);
+    assert.strictEqual(ColumnInfo.is({ name: 'Id', type: 'uuid' }), true);
+    assert.strictEqual(ColumnInfo.is({ name: 'Start', type: 'date' }), true);
+    assert.strictEqual(ColumnInfo.is({ name: 'Elapsed', type: 'time' }), true);
+  });
+
+  it('rejects invalid type', () => {
+    assert.strictEqual(ColumnInfo.is({ name: 'Foo', type: 'varchar' }), false);
+    assert.strictEqual(ColumnInfo.is({ name: 'Foo', type: '' }), false);
+  });
+
+  it('rejects missing type', () => {
+    assert.strictEqual(ColumnInfo.is({ name: 'Foo' }), false);
+    assert.strictEqual(ColumnInfo.is({}), false);
+  });
+
+  it('rejects non-string name', () => {
+    assert.strictEqual(ColumnInfo.is({ name: 123, type: 'string' }), false);
+  });
+
+  it('rejects null and undefined', () => {
+    assert.strictEqual(ColumnInfo.is(null), false);
+    assert.strictEqual(ColumnInfo.is(undefined), false);
+  });
+});
+
+describe('Property with column info', () => {
+  it('has no column by default', () => {
+    const prop = new Property('duration', 'SystemMetaData', 'PerformanceAndHealth');
+    assert.strictEqual(prop.column, undefined);
+  });
+
+  it('can be assigned a column', () => {
+    const prop = new Property('duration', 'SystemMetaData', 'PerformanceAndHealth');
+    prop.column = { name: 'Duration', type: 'real' };
+    assert.strictEqual(prop.column.name, 'Duration');
+    assert.strictEqual(prop.column.type, 'real');
+  });
+
+  it('can have a column without a name', () => {
+    const prop = new Property('outcome', 'SystemMetaData', 'FeatureInsight');
+    prop.column = { type: 'string' };
+    assert.strictEqual(prop.column.name, undefined);
+    assert.strictEqual(prop.column.type, 'string');
+  });
+});
+

--- a/src/tests/mocha/common-property-test.ts
+++ b/src/tests/mocha/common-property-test.ts
@@ -5,118 +5,24 @@ import * as assert from 'assert';
 import * as assertHelper from './assert-helper';
 import * as path from 'path';
 import { cwd } from "process";
-import { Property, ColumnType, ColumnInfo } from "../../lib/common-properties";
+import { Property } from "../../lib/common-properties";
 
 const sourceDir = path.join(cwd(), 'src/tests/mocha/resources/');
 const excludeDirs = [path.join(sourceDir, 'source'), path.join(sourceDir, 'source-1')];
 
 describe('GDPR common property extraction', () => {
-  it('find files', function () {
-    const parser = new Parser([sourceDir], excludeDirs, true, false);
-    //@ts-expect-error accessing private method for testing
-    const filePaths = parser.findFilesWithCommonProperties(sourceDir);
-    assertHelper.sameValues(filePaths, [path.join(cwd(), '/src/tests/mocha/resources/common-prop.ts')]);
-  });
+	it('find files', function () {
+		const parser = new Parser([sourceDir], excludeDirs, true, false);
+		//@ts-expect-error accessing private method for testing
+		const filePaths = parser.findFilesWithCommonProperties(sourceDir);
+		assertHelper.sameValues(filePaths, [path.join(cwd(), '/src/tests/mocha/resources/common-prop.ts')]);
+	});
 
-  it('extract declarations', function () {
-    const parser = new Parser([sourceDir], excludeDirs, true, false);
-    //@ts-expect-error accessing private method for testing
-    const commonProperties = parser.findCommonProperties(sourceDir);
-    assert.deepStrictEqual(commonProperties.properties[0], new Property('timestamp', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none'));
-    assert.deepStrictEqual(commonProperties.properties[1], new Property('machineid', 'EndUserPseudonymizedInformation', 'FeatureInsight', undefined, undefined, undefined, 'MacAddressHash'));
-  });
+	it('extract declarations', function () {
+		const parser = new Parser([sourceDir], excludeDirs, true, false);
+		//@ts-expect-error accessing private method for testing
+		const commonProperties = parser.findCommonProperties(sourceDir);
+		assert.deepStrictEqual(commonProperties.properties[0], new Property('timestamp', 'SystemMetaData', 'FeatureInsight', undefined, undefined, undefined, 'none'));
+		assert.deepStrictEqual(commonProperties.properties[1], new Property('machineid', 'EndUserPseudonymizedInformation', 'FeatureInsight', undefined, undefined, undefined, 'MacAddressHash'));
+	});
 });
-
-describe('ColumnType', () => {
-  it('parses canonical type names', () => {
-    const canonicalTypes: ColumnType[] = ['bool', 'int', 'long', 'real', 'decimal', 'dynamic', 'guid', 'string', 'datetime', 'timespan'];
-    for (const type of canonicalTypes) {
-      assert.strictEqual(ColumnType.fromString(type), type);
-    }
-  });
-
-  it('parses alias type names to canonical form', () => {
-    assert.strictEqual(ColumnType.fromString('boolean'), 'bool');
-    assert.strictEqual(ColumnType.fromString('double'), 'real');
-    assert.strictEqual(ColumnType.fromString('uuid'), 'guid');
-    assert.strictEqual(ColumnType.fromString('uniqueid'), 'guid');
-    assert.strictEqual(ColumnType.fromString('date'), 'datetime');
-    assert.strictEqual(ColumnType.fromString('time'), 'timespan');
-  });
-
-  it('is case-insensitive', () => {
-    assert.strictEqual(ColumnType.fromString('String'), 'string');
-    assert.strictEqual(ColumnType.fromString('BOOL'), 'bool');
-    assert.strictEqual(ColumnType.fromString('DateTime'), 'datetime');
-    assert.strictEqual(ColumnType.fromString('BOOLEAN'), 'bool');
-    assert.strictEqual(ColumnType.fromString('Double'), 'real');
-  });
-
-  it('returns undefined for unknown types', () => {
-    assert.strictEqual(ColumnType.fromString('unknown'), undefined);
-    assert.strictEqual(ColumnType.fromString('varchar'), undefined);
-    assert.strictEqual(ColumnType.fromString(''), undefined);
-    assert.strictEqual(ColumnType.fromString('number'), undefined);
-  });
-});
-
-describe('ColumnInfo', () => {
-  it('validates a complete column info with name and type', () => {
-    assert.strictEqual(ColumnInfo.is({ name: 'Duration', type: 'real' }), true);
-    assert.strictEqual(ColumnInfo.is({ name: 'Outcome', type: 'string' }), true);
-  });
-
-  it('validates column info without name (name is optional)', () => {
-    assert.strictEqual(ColumnInfo.is({ type: 'long' }), true);
-    assert.strictEqual(ColumnInfo.is({ type: 'bool' }), true);
-  });
-
-  it('accepts alias type names', () => {
-    assert.strictEqual(ColumnInfo.is({ name: 'Active', type: 'boolean' }), true);
-    assert.strictEqual(ColumnInfo.is({ name: 'Latency', type: 'double' }), true);
-    assert.strictEqual(ColumnInfo.is({ name: 'Id', type: 'uuid' }), true);
-    assert.strictEqual(ColumnInfo.is({ name: 'Start', type: 'date' }), true);
-    assert.strictEqual(ColumnInfo.is({ name: 'Elapsed', type: 'time' }), true);
-  });
-
-  it('rejects invalid type', () => {
-    assert.strictEqual(ColumnInfo.is({ name: 'Foo', type: 'varchar' }), false);
-    assert.strictEqual(ColumnInfo.is({ name: 'Foo', type: '' }), false);
-  });
-
-  it('rejects missing type', () => {
-    assert.strictEqual(ColumnInfo.is({ name: 'Foo' }), false);
-    assert.strictEqual(ColumnInfo.is({}), false);
-  });
-
-  it('rejects non-string name', () => {
-    assert.strictEqual(ColumnInfo.is({ name: 123, type: 'string' }), false);
-  });
-
-  it('rejects null and undefined', () => {
-    assert.strictEqual(ColumnInfo.is(null), false);
-    assert.strictEqual(ColumnInfo.is(undefined), false);
-  });
-});
-
-describe('Property with column info', () => {
-  it('has no column by default', () => {
-    const prop = new Property('duration', 'SystemMetaData', 'PerformanceAndHealth');
-    assert.strictEqual(prop.column, undefined);
-  });
-
-  it('can be assigned a column', () => {
-    const prop = new Property('duration', 'SystemMetaData', 'PerformanceAndHealth');
-    prop.column = { name: 'Duration', type: 'real' };
-    assert.strictEqual(prop.column.name, 'Duration');
-    assert.strictEqual(prop.column.type, 'real');
-  });
-
-  it('can have a column without a name', () => {
-    const prop = new Property('outcome', 'SystemMetaData', 'FeatureInsight');
-    prop.column = { type: 'string' };
-    assert.strictEqual(prop.column.name, undefined);
-    assert.strictEqual(prop.column.type, 'string');
-  });
-});
-

--- a/src/tests/mocha/table-tests.ts
+++ b/src/tests/mocha/table-tests.ts
@@ -141,9 +141,9 @@ describe('Flat table - GDPR Comment', () => {
 		};
 		const declarations = await extractAndResolveDeclarations([sourceSpec]);
 		const tableInfos = declarations.tableInfos;
-		assert.strictEqual(tableInfos.length, 1);
+		assert.strictEqual(Object.keys(tableInfos).length, 1);
 
-		const table = tableInfos[0];
+		const table = tableInfos['EOneTable'];
 		assert.strictEqual(table.name, 'EOneTable');
 		assert.strictEqual(table.backfill, false);
 		assert.strictEqual(table.commonProperties, 'standard');
@@ -207,9 +207,9 @@ describe('Flat table - TS definition', () => {
 		};
 		const declarations = await extractAndResolveDeclarations([sourceSpec]);
 		const tableInfos = declarations.tableInfos;
-		assert.strictEqual(tableInfos.length, 1);
+		assert.strictEqual(Object.keys(tableInfos).length, 1);
 
-		const table = tableInfos[0];
+		const table = tableInfos['monacoworkbench_inlinecompletion.endoflife'];
 		assert.strictEqual(table.name, 'monacoworkbench_inlinecompletion.endoflife');
 		assert.strictEqual(table.backfill, false);
 		assert.strictEqual(table.commonProperties, 'standard');

--- a/src/tests/mocha/table-tests.ts
+++ b/src/tests/mocha/table-tests.ts
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { Parser } from "../../lib/parser";
+import * as assert from 'assert';
+import { Property, ColumnType, ColumnInfo } from "../../lib/common-properties";
+import { cwd } from 'process';
+import * as path from 'path';
+
+const sourceDir = path.join(cwd(), 'src/tests/mocha/tableResources/source');
+
+describe('ColumnType', () => {
+	it('parses canonical type names', () => {
+		const canonicalTypes: ColumnType[] = ['bool', 'int', 'long', 'real', 'decimal', 'dynamic', 'guid', 'string', 'datetime', 'timespan'];
+		for (const type of canonicalTypes) {
+			assert.strictEqual(ColumnType.fromString(type), type);
+		}
+	});
+
+	it('parses alias type names to canonical form', () => {
+		assert.strictEqual(ColumnType.fromString('boolean'), 'bool');
+		assert.strictEqual(ColumnType.fromString('double'), 'real');
+		assert.strictEqual(ColumnType.fromString('uuid'), 'guid');
+		assert.strictEqual(ColumnType.fromString('uniqueid'), 'guid');
+		assert.strictEqual(ColumnType.fromString('date'), 'datetime');
+		assert.strictEqual(ColumnType.fromString('time'), 'timespan');
+	});
+
+	it('is case-insensitive', () => {
+		assert.strictEqual(ColumnType.fromString('String'), 'string');
+		assert.strictEqual(ColumnType.fromString('BOOL'), 'bool');
+		assert.strictEqual(ColumnType.fromString('DateTime'), 'datetime');
+		assert.strictEqual(ColumnType.fromString('BOOLEAN'), 'bool');
+		assert.strictEqual(ColumnType.fromString('Double'), 'real');
+	});
+
+	it('returns undefined for unknown types', () => {
+		assert.strictEqual(ColumnType.fromString('unknown'), undefined);
+		assert.strictEqual(ColumnType.fromString('varchar'), undefined);
+		assert.strictEqual(ColumnType.fromString(''), undefined);
+		assert.strictEqual(ColumnType.fromString('number'), undefined);
+	});
+});
+
+describe('ColumnInfo', () => {
+	it('validates a complete column info with name and type', () => {
+		assert.strictEqual(ColumnInfo.is({ name: 'Duration', type: 'real' }), true);
+		assert.strictEqual(ColumnInfo.is({ name: 'Outcome', type: 'string' }), true);
+	});
+
+	it('validates column info without name (name is optional)', () => {
+		assert.strictEqual(ColumnInfo.is({ type: 'long' }), true);
+		assert.strictEqual(ColumnInfo.is({ type: 'bool' }), true);
+	});
+
+	it('accepts alias type names', () => {
+		assert.strictEqual(ColumnInfo.is({ name: 'Active', type: 'boolean' }), true);
+		assert.strictEqual(ColumnInfo.is({ name: 'Latency', type: 'double' }), true);
+		assert.strictEqual(ColumnInfo.is({ name: 'Id', type: 'uuid' }), true);
+		assert.strictEqual(ColumnInfo.is({ name: 'Start', type: 'date' }), true);
+		assert.strictEqual(ColumnInfo.is({ name: 'Elapsed', type: 'time' }), true);
+	});
+
+	it('rejects invalid type', () => {
+		assert.strictEqual(ColumnInfo.is({ name: 'Foo', type: 'varchar' }), false);
+		assert.strictEqual(ColumnInfo.is({ name: 'Foo', type: '' }), false);
+	});
+
+	it('rejects missing type', () => {
+		assert.strictEqual(ColumnInfo.is({ name: 'Foo' }), false);
+		assert.strictEqual(ColumnInfo.is({}), false);
+	});
+
+	it('rejects non-string name', () => {
+		assert.strictEqual(ColumnInfo.is({ name: 123, type: 'string' }), false);
+	});
+
+	it('rejects null and undefined', () => {
+		assert.strictEqual(ColumnInfo.is(null), false);
+		assert.strictEqual(ColumnInfo.is(undefined), false);
+	});
+});
+
+describe('Property with column info', () => {
+	it('has no column by default', () => {
+		const prop = new Property('duration', 'SystemMetaData', 'PerformanceAndHealth');
+		assert.strictEqual(prop.column, undefined);
+	});
+
+	it('can be assigned a column', () => {
+		const prop = new Property('duration', 'SystemMetaData', 'PerformanceAndHealth');
+		prop.column = { name: 'Duration', type: 'real' };
+		assert.strictEqual(prop.column.name, 'Duration');
+		assert.strictEqual(prop.column.type, 'real');
+	});
+
+	it('can have a column without a name', () => {
+		const prop = new Property('outcome', 'SystemMetaData', 'FeatureInsight');
+		prop.column = { type: 'string' };
+		assert.strictEqual(prop.column.name, undefined);
+		assert.strictEqual(prop.column.type, 'string');
+	});
+});
+
+describe('Flat table', () => {
+	it('Parse table instructions', async () => {
+		const parser = new Parser([sourceDir], [], false, false);
+		const declarations = await parser.extractDeclarations();
+		assert.strictEqual(declarations.events.dataPoints.length, 1);
+		const event = declarations.events.dataPoints[0];
+		assert.strictEqual(event.name, 'EOne');
+		assert.strictEqual(event.tableInfo?.name, 'EOneTable');
+		assert.strictEqual(event.tableInfo?.commonProperties, 'standard');
+		assert.strictEqual(event.tableInfo?.backfill, false);
+		assert.strictEqual(event.properties.length, 3);
+		const types: Map<string, string> = new Map([
+			['count', 'int'],
+			['date', 'datetime'],
+			['isValid', 'bool']
+		]);
+		for (const prop of event.properties) {
+			assert.ok(prop instanceof Property);
+			const expectedType = types.get(prop.name);
+			assert.strictEqual(expectedType, prop.column?.type);
+		}
+	});
+});

--- a/src/tests/mocha/table-tests.ts
+++ b/src/tests/mocha/table-tests.ts
@@ -6,6 +6,8 @@ import { Property, ColumnType, ColumnInfo } from "../../lib/common-properties";
 import { cwd } from 'process';
 import * as path from 'path';
 import { TsParser } from '../../lib/ts-parser';
+import { extractAndResolveDeclarations } from '../../lib/save-declarations';
+import type { SourceSpec } from '../..';
 
 const sourceDir = path.join(cwd(), 'src/tests/mocha/tableResources/source');
 
@@ -124,6 +126,43 @@ describe('Flat table - GDPR Comment', () => {
 			assert.strictEqual(expectedType, prop.column?.type);
 		}
 	});
+	it('Generate table info JSON', async () => {
+		const sourceSpec: SourceSpec = {
+			sourceDirs: [path.join(sourceDir, 'comment')],
+			excludedDirs: [],
+			parserOptions: {
+				eventPrefix: '',
+    			applyEndpoints: false,
+    			patchDebugEvents: false,
+    			lowerCaseEvents: false,
+    			silenceOutput: true,
+    			verbose: false
+			}
+		};
+		const declarations = await extractAndResolveDeclarations([sourceSpec]);
+		const tableInfos = declarations.tableInfos;
+		assert.strictEqual(tableInfos.length, 1);
+
+		const table = tableInfos[0];
+		assert.strictEqual(table.name, 'EOneTable');
+		assert.strictEqual(table.backfill, false);
+		assert.strictEqual(table.commonProperties, 'standard');
+		assert.strictEqual(table.columns.length, 3);
+
+		const expectedColumns = new Map([
+			['count', { type: 'int', bag: { name: 'count', store: 'Properties' } }],
+			['date', { type: 'datetime', bag: { name: 'date', store: 'Properties' } }],
+			['isValid', { type: 'bool', bag: { name: 'isvalid', store: 'Properties' } }],
+		]);
+		const actualColumns = new Map(table.columns.map(c => [c.name, c]));
+		for (const [name, expected] of expectedColumns) {
+			const col = actualColumns.get(name);
+			assert.ok(col, `Column '${name}' not found`);
+			assert.strictEqual(col.type, expected.type);
+			assert.strictEqual(col.bag.name, expected.bag.name);
+			assert.strictEqual(col.bag.store, expected.bag.store);
+		}
+	});
 });
 
 describe('Flat table - TS definition', () => {
@@ -131,12 +170,69 @@ describe('Flat table - TS definition', () => {
 		const tsParser = new TsParser(path.resolve(sourceDir, 'ts-declaration'), [], true, false);
 		const declarations = tsParser.parseFiles();
 		const event = declarations['Event1'];
-		assert.strictEqual(event.tableInfo?.name, 'monacoworkbench_inlinecompletion.endoflife');
-		assert.strictEqual(event.tableInfo?.commonProperties, 'standard');
-		assert.strictEqual(event.tableInfo?.backfill, false);
+		assert.strictEqual(event.$tableinfo?.name, 'monacoworkbench_inlinecompletion.endoflife');
+		assert.strictEqual(event.$tableinfo?.commonProperties, 'standard');
+		assert.strictEqual(event.$tableinfo?.backfill, false);
 		const columns = new Map([
-			['extennsionid', { name: 'extennsionId', type: 'string' }],
+			['extensionid', { name: 'extensionId', type: 'string' }],
 			['groupid', { name: 'groupId', type: 'string' }],
+			['shown', { name: 'isShown', type: 'bool' }],
+			['timeuntilshown', { name: 'timeUntilShown', type: 'int' }],
+			['timeuntilproviderrequest', { name: 'timeUntilProviderRequest', type: 'int' }],
+			['timeuntilproviderresponse', { name: 'timeUntilProviderResponse', type: 'int' }],
+			['reason', { name: 'reason', type: 'string' }],
+			['preceeded', { name: 'isPreceded', type: 'bool' }],
+			['languageid', { name: 'languageId', type: 'string' }],
 		]);
+		for (const prop of columns.keys()) {
+			const columnInfo = columns.get(prop);
+			const property = event[prop];
+			assert.strictEqual(property.column?.name, columnInfo?.name);
+			assert.strictEqual(property.column?.type, columnInfo?.type);
+		}
+	});
+
+	it('Generate table info JSON', async () => {
+		const sourceSpec: SourceSpec = {
+			sourceDirs: [path.join(sourceDir, 'ts-declaration')],
+			excludedDirs: [],
+			parserOptions: {
+				eventPrefix: '',
+    			applyEndpoints: false,
+    			patchDebugEvents: false,
+    			lowerCaseEvents: false,
+    			silenceOutput: true,
+    			verbose: false
+			}
+		};
+		const declarations = await extractAndResolveDeclarations([sourceSpec]);
+		const tableInfos = declarations.tableInfos;
+		assert.strictEqual(tableInfos.length, 1);
+
+		const table = tableInfos[0];
+		assert.strictEqual(table.name, 'monacoworkbench_inlinecompletion.endoflife');
+		assert.strictEqual(table.backfill, false);
+		assert.strictEqual(table.commonProperties, 'standard');
+		assert.strictEqual(table.columns.length, 9);
+		const expectedColumns = new Map([
+			['extensionId', { type: 'string', bag: { name: 'extensionid', store: 'Properties' } }],
+			['groupId', { type: 'string', bag: { name: 'groupid', store: 'Properties' } }],
+			['isShown', { type: 'bool', bag: { name: 'shown', store: 'Measures' } }],
+			['timeUntilShown', { type: 'int', bag: { name: 'timeuntilshown', store: 'Measures' } }],
+			['timeUntilProviderRequest', { type: 'int', bag: { name: 'timeuntilproviderrequest', store: 'Measures' } }],
+			['timeUntilProviderResponse', { type: 'int', bag: { name: 'timeuntilproviderresponse', store: 'Measures' } }],
+			['reason', { type: 'string', bag: { name: 'reason', store: 'Properties' } }],
+			['isPreceded', { type: 'bool', bag: { name: 'preceeded', store: 'Measures' } }],
+			['languageId', { type: 'string', bag: { name: 'languageid', store: 'Properties' } }],
+		]);
+		const actualColumns = new Map(table.columns.map(c => [c.name, c]));
+		for (const [name, expected] of expectedColumns) {
+			const col = actualColumns.get(name);
+			assert.ok(col, `Column '${name}' not found`);
+			assert.strictEqual(col.type, expected.type);
+			assert.strictEqual(col.bag.name, expected.bag.name);
+			assert.strictEqual(col.bag.store, expected.bag.store);
+		}
+
 	});
 });

--- a/src/tests/mocha/table-tests.ts
+++ b/src/tests/mocha/table-tests.ts
@@ -5,6 +5,7 @@ import * as assert from 'assert';
 import { Property, ColumnType, ColumnInfo } from "../../lib/common-properties";
 import { cwd } from 'process';
 import * as path from 'path';
+import { TsParser } from '../../lib/ts-parser';
 
 const sourceDir = path.join(cwd(), 'src/tests/mocha/tableResources/source');
 
@@ -101,9 +102,9 @@ describe('Property with column info', () => {
 	});
 });
 
-describe('Flat table', () => {
+describe('Flat table - GDPR Comment', () => {
 	it('Parse table instructions', async () => {
-		const parser = new Parser([sourceDir], [], false, false);
+		const parser = new Parser([path.join(sourceDir, 'comment')], [], false, false);
 		const declarations = await parser.extractDeclarations();
 		assert.strictEqual(declarations.events.dataPoints.length, 1);
 		const event = declarations.events.dataPoints[0];
@@ -121,6 +122,16 @@ describe('Flat table', () => {
 			assert.ok(prop instanceof Property);
 			const expectedType = types.get(prop.name);
 			assert.strictEqual(expectedType, prop.column?.type);
+		}
+	});
+});
+
+describe('Flat table - TS definition', () => {
+	it('Parse table instructions', () => {
+		const tsParser = new TsParser(path.resolve(sourceDir, 'ts-declaration'), [], true, false);
+		const declarations = tsParser.parseFiles();
+		for (const declaration of declarations) {
+			console.log(`Event: ${declaration.name}`);
 		}
 	});
 });

--- a/src/tests/mocha/table-tests.ts
+++ b/src/tests/mocha/table-tests.ts
@@ -130,8 +130,13 @@ describe('Flat table - TS definition', () => {
 	it('Parse table instructions', () => {
 		const tsParser = new TsParser(path.resolve(sourceDir, 'ts-declaration'), [], true, false);
 		const declarations = tsParser.parseFiles();
-		for (const declaration of declarations) {
-			console.log(`Event: ${declaration.name}`);
-		}
+		const event = declarations['Event1'];
+		assert.strictEqual(event.tableInfo?.name, 'monacoworkbench_inlinecompletion.endoflife');
+		assert.strictEqual(event.tableInfo?.commonProperties, 'standard');
+		assert.strictEqual(event.tableInfo?.backfill, false);
+		const columns = new Map([
+			['extennsionid', { name: 'extennsionId', type: 'string' }],
+			['groupid', { name: 'groupId', type: 'string' }],
+		]);
 	});
 });

--- a/src/tests/mocha/tableResources/source/comment/file1.ts
+++ b/src/tests/mocha/tableResources/source/comment/file1.ts
@@ -5,7 +5,7 @@ import { sendEvent, EventData } from "../lib/telemetry";
 
 /* __GDPR__
    "EOne" : {
-     "$tableInfo": { "name": "EOneTable", "defaultProperties": "standard", "backfill": false },
+     "$tableInfo": { "name": "EOneTable", "commonProperties": "standard", "backfill": false },
      "count": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "int" },
      "date": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "datetime" },
      "isValid": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "bool" }

--- a/src/tests/mocha/tableResources/source/comment/file1.ts
+++ b/src/tests/mocha/tableResources/source/comment/file1.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-import { sendEvent, EventData } from "./lib/telemetry";
+import { sendEvent, EventData } from "../lib/telemetry";
 
 
 /* __GDPR__

--- a/src/tests/mocha/tableResources/source/file1.ts
+++ b/src/tests/mocha/tableResources/source/file1.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+import { sendEvent, EventData } from "./lib/telemetry";
+
+
+/* __GDPR__
+   "EOne" : {
+     "$table": { "name": "EOneTable", "defaultProperties": "standard", "backfill": false },
+     "count": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "int" },
+     "date": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "datetime" },
+     "isValid": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "bool" }
+   }
+ */
+function sendEventEOne() {
+  sendEvent('EOne', {
+    'count': '10',
+    'date': '2024-06-05T12:34:56Z',
+    'isValid': 'true'
+  });
+}

--- a/src/tests/mocha/tableResources/source/file1.ts
+++ b/src/tests/mocha/tableResources/source/file1.ts
@@ -5,7 +5,7 @@ import { sendEvent, EventData } from "./lib/telemetry";
 
 /* __GDPR__
    "EOne" : {
-     "$table": { "name": "EOneTable", "defaultProperties": "standard", "backfill": false },
+     "$tableInfo": { "name": "EOneTable", "defaultProperties": "standard", "backfill": false },
      "count": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "int" },
      "date": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "datetime" },
      "isValid": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "type": "bool" }

--- a/src/tests/mocha/tableResources/source/lib/publicLog.ts
+++ b/src/tests/mocha/tableResources/source/lib/publicLog.ts
@@ -1,0 +1,43 @@
+export interface IPropertyData {
+	classification: 'SystemMetaData' | 'CallstackOrException' | 'CustomerContent' | 'PublicNonPersonalData' | 'EndUserPseudonymizedInformation';
+	purpose: 'PerformanceAndHealth' | 'FeatureInsight' | 'BusinessInsight';
+	comment: string;
+	expiration?: string;
+	endpoint?: string;
+}
+
+export interface TableInfo {
+	name: string;
+	commonProperties?: string;
+	backfill?: boolean;
+}
+
+export interface IGDPRProperty {
+	owner: string;
+	comment: string;
+	expiration?: string;
+	$tableInfo?: TableInfo;
+	readonly [name: string]: IPropertyData | undefined | IGDPRProperty | string | TableInfo;
+}
+
+type IGDPRPropertyWithoutMetadata = Omit<IGDPRProperty, 'owner' | 'comment' | 'expiration' | '$tableInfo'>;
+export type OmitMetadata<T> = Omit<T, 'owner' | 'comment' | 'expiration' | '$tableInfo'>;
+
+export type ClassifiedEvent<T extends IGDPRPropertyWithoutMetadata> = {
+	[k in keyof T]: unknown;
+};
+
+export type StrictPropertyChecker<TEvent, TClassification, TError> = keyof TEvent extends keyof OmitMetadata<TClassification> ? keyof OmitMetadata<TClassification> extends keyof TEvent ? TEvent : TError : TError;
+
+export type StrictPropertyCheckError = { error: 'Type of classified event does not match event properties' };
+
+export type StrictPropertyCheck<T extends IGDPRProperty, E> = StrictPropertyChecker<E, ClassifiedEvent<OmitMetadata<T>>, StrictPropertyCheckError>;
+
+// The TS parser is looking for two commands, publicLog2 and publicLogError2. They both represent the same thing
+export function publicLog2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>): void {
+    return;
+}
+
+export function publicLogError2<E extends ClassifiedEvent<OmitMetadata<T>> = never, T extends IGDPRProperty = never>(eventName: string, data?: StrictPropertyCheck<T, E>): void {
+    return;
+}

--- a/src/tests/mocha/tableResources/source/lib/telemetry.ts
+++ b/src/tests/mocha/tableResources/source/lib/telemetry.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface EventData {
+    [property: string]: string | EventData;
+}
+
+function addCommonProperties(event: EventData) : EventData {
+    // __GDPR__COMMON__ "timestamp" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+    event.timestamp = 'timestamp_value';
+    // __GDPR__COMMON__ "machineid" : { "endPoint": "MacAddressHash", "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight" }
+    event.machineid = 'machineid_value';
+    return event;
+}
+
+function _sendEvent(event: string, data: EventData) {
+    // send event
+}
+
+export function sendEvent(event: string, data: EventData) : void {
+    data = addCommonProperties(data);
+    _sendEvent(event, data);
+}

--- a/src/tests/mocha/tableResources/source/ts-declaration/endoflife.ts
+++ b/src/tests/mocha/tableResources/source/ts-declaration/endoflife.ts
@@ -1,0 +1,44 @@
+import { publicLog2 } from '../lib/publicLog';
+
+export type InlineCompletionEndOfLifeEvent = {
+	// request
+	languageId: string;
+	extensionId: string;
+	groupId: string | undefined;
+	// behavior
+	shown: boolean;
+	timeUntilShown: number | undefined;
+	timeUntilProviderRequest: number | undefined;
+	timeUntilProviderResponse: number | undefined;
+	reason: 'accepted' | 'rejected' | 'ignored' | undefined;
+	preceeded: boolean | undefined;
+};
+
+type InlineCompletionsEndOfLifeClassification = {
+	owner: 'benibenj';
+	comment: 'Inline completions ended. @sentToGitHub';
+	$tableInfo: { name: 'monacoworkbench_inlinecompletion.endoflife'; commonProperties: 'standard'; backfill: false };
+	extensionId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The identifier for the extension that contributed the inline completion'; type: 'string' };
+	groupId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The group ID of the extension that contributed the inline completion'; type: 'string' };
+	shown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was shown to the user'; column: { name: 'isShown'; type: 'bool' } };
+	timeUntilShown: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be shown after the request'; type: 'int' };
+	timeUntilProviderRequest: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be requested from the provider'; type: 'int' };
+	timeUntilProviderResponse: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The time it took for the inline completion to be shown after the request'; type: 'int' };
+	reason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The reason for the inline completion ending'; type: 'string' };
+	preceeded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the inline completion was preceeded by another one'; column: { name: 'isPreceded'; type: 'bool' } };
+	languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The language ID of the document where the inline completion was shown'; type: 'string' };
+};
+
+const sentEvent: InlineCompletionEndOfLifeEvent = {
+	languageId: 'typescript',
+	extensionId: 'my-extension',
+	groupId: 'my-group',
+	shown: true,
+	timeUntilShown: 100,
+	timeUntilProviderRequest: 50,
+	timeUntilProviderResponse: 150,
+	reason: 'accepted',
+	preceeded: false
+};
+
+publicLog2<InlineCompletionEndOfLifeEvent, InlineCompletionsEndOfLifeClassification>('Event1', sentEvent);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -62,6 +62,7 @@
   "exclude": [
     "./src/telemetry-sources",
     "./src/tests/mocha/resources",
+    "./src/tests/mocha/tableResources",
     "**/*.d.ts"
   ]
 }

--- a/vscode-telemetry-extractor.d.ts
+++ b/vscode-telemetry-extractor.d.ts
@@ -35,8 +35,15 @@ export interface Events {
     [key: string]: Event;
 }
 
+export type TableInfo = {
+    name: string;
+    commonProperties: 'standard';
+    backfill: boolean | string;
+}
+
 export interface Event {
-    [key: string]: Property | string | undefined;
+    [key: string]: Property | TableInfo | string | undefined;
+    tableInfo?: TableInfo;
     comment?: string;
     expiration?: string;
 }
@@ -48,6 +55,7 @@ export interface Property {
     purpose: string;
     endPoint?: string;
     isMeasurement?: boolean;
+    column?: { name?: string; type: string };
 }
 
 /**

--- a/vscode-telemetry-extractor.d.ts
+++ b/vscode-telemetry-extractor.d.ts
@@ -35,15 +35,8 @@ export interface Events {
     [key: string]: Event;
 }
 
-export type TableInfo = {
-    name: string;
-    commonProperties: 'standard';
-    backfill: boolean | string;
-}
-
 export interface Event {
-    [key: string]: Property | TableInfo | string | undefined;
-    tableInfo?: TableInfo;
+    [key: string]: Property | string | undefined;
     comment?: string;
     expiration?: string;
 }
@@ -58,11 +51,30 @@ export interface Property {
     column?: { name?: string; type: string };
 }
 
+export type ColumnType =
+    'bool' |
+    'int' |
+    'long' |
+    'real' |
+    'decimal' |
+    'dynamic' |
+    'guid' |
+    'string' |
+    'datetime' |
+    'timespan';
+
+export interface TableInfo {
+    name: string;
+    commonProperties: 'standard';
+    backfill: boolean | string;
+    columns: { name: string; type: ColumnType; bag: { store: 'Measures' | 'Properties'; name: string }}[];
+}
+
 /**
  * Extracts and resolves all typescript declarations from a series of different sources into a formatted object
  * @param sourceSpecs The various sources and their options which you would like to extract from
  */
-export declare function extractAndResolveDeclarations(sourceSpecs: Array<SourceSpec>): Promise<{ events: Events, commonProperties: CommonProperties }>;
+export declare function extractAndResolveDeclarations(sourceSpecs: Array<SourceSpec>): Promise<{ events: Events, commonProperties: CommonProperties, tableInfos: TableInfo[] }>;
 
 /**
  * Parses a valid extractor config file into an array of sourceSpecs that can be passed into an extract function


### PR DESCRIPTION
Enhance GDPR comments by adding support for table information, including column details and original property names. Implement tests to ensure functionality and address compilation issues. Update TypeScript parser to handle new table info structures.