### PR TITLE
Fix deterministic duplicate event extraction

### DIFF
--- a/src/lib/event-definition.ts
+++ b/src/lib/event-definition.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export interface EventDefinition {
+    properties: Record<string, unknown>;
+    location: string;
+}

--- a/src/lib/operations.ts
+++ b/src/lib/operations.ts
@@ -17,6 +17,9 @@ export function merge(target: Fragments | Events, source: Fragments | Events) {
                 if (!eventsAreCompatible(found, item)) {
                     continue;
                 }
+                if (found.tableInfo === undefined) {
+                    found.tableInfo = item.tableInfo;
+                }
                 // Merge unique properties from source into target
                 for (const prop of item.properties) {
                     if (prop instanceof Property) {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -10,16 +10,8 @@ import { Property, CommonProperties } from './common-properties';
 import { Events, Event, TableInfo } from './events';
 import { Declarations } from './declarations';
 import { merge, findOrCreate, populateProperties, makeExclusionsRelativeToSource } from './operations';
-
-export interface EventPropertySignature {
-    classification: string;
-    purpose: string;
-}
-
-export interface EventDefinition {
-    properties: Record<string, EventPropertySignature>;
-    location: string;
-}
+import { parseRipgrepFilePaths } from './ripgrep';
+import { EventDefinition } from './event-definition';
 
 export class Parser {
 
@@ -137,7 +129,6 @@ export class Parser {
 
     private findEvents(sourceDir: string) {
         const filesWithEvents = this.asAbsoluteFilePaths(this.findFilesWithEvents(sourceDir));
-        const seenEvents = new Set<string>();
 
         // Using [\s\S]* instead of .* since the latter does not match when using /m option
         const eventMatcher = /\/\*\s*__GDPR__\b([\s\S]*?)\*\//mg;
@@ -152,12 +143,7 @@ export class Parser {
                 const lineNumber = this.getLineNumber(fileContents, match.index);
                 this.addEventDefinition(eventName, conflictProperties, `${filePath}:${lineNumber}`);
 
-                if (seenEvents.has(eventName)) {
-                    return;
-                }
-
-                seenEvents.add(eventName);
-                const event = findOrCreate(eventDeclarations, eventName);
+                const event = new Event(eventName);
                 if (event instanceof Event && eventProperties['$tableInfo'] !== undefined) {
                     const tableInfo: TableInfo | undefined = TableInfo.fromObject(eventProperties['$tableInfo']);
                     if (tableInfo) {
@@ -166,6 +152,9 @@ export class Parser {
                 }
                 // Get the propeties which the event possesses
                 populateProperties(eventProperties, event, this.applyEndpoints);
+                const currentDeclaration = new Events();
+                currentDeclaration.dataPoints.push(event);
+                merge(eventDeclarations, currentDeclaration);
             } catch (error) {
                 console.error(`Event Declaration Error: ${error} in file ${filePath}`);
                 console.error(`Source comment:\n${match[0]}`);
@@ -183,23 +172,14 @@ export class Parser {
         return definitions;
     }
 
-    private addEventDefinition(eventName: string, properties: Record<string, EventPropertySignature>, location: string) {
+    private addEventDefinition(eventName: string, properties: Record<string, unknown>, location: string) {
         const existing = this.eventDefinitions.get(eventName) ?? [];
         existing.push({ properties, location });
         this.eventDefinitions.set(eventName, existing);
     }
 
-    private extractConflictProperties(eventProperties: Record<string, unknown>): Record<string, EventPropertySignature> {
-        const result: Record<string, EventPropertySignature> = {};
-        for (const [key, value] of Object.entries(eventProperties)) {
-            if (value && typeof value === 'object' && !Array.isArray(value)) {
-                const obj = value as Record<string, unknown>;
-                if (typeof obj.classification === 'string' && typeof obj.purpose === 'string') {
-                    result[key] = { classification: obj.classification, purpose: obj.purpose };
-                }
-            }
-        }
-        return result;
+    private extractConflictProperties(eventProperties: Record<string, unknown>): Record<string, unknown> {
+        return { ...eventProperties };
     }
 
     private getLineNumber(fileContents: string, index: number | undefined) {
@@ -216,7 +196,7 @@ export class Parser {
         const ripgrepArgs = ['--files-with-matches', '--glob', '*.ts', '--glob', '*.tsx', '--glob', '*.cs', ...exclusions, '--regexp', ripgrepPattern, '--', sourceDir];
         try {
             const filePaths = cp.execFileSync(rgPath, ripgrepArgs, { encoding: 'ascii', cwd: `${sourceDir}` });
-            return filePaths.split(/(?:\r\n|\r|\n)/g).filter(path => path && path.length > 0);
+            return parseRipgrepFilePaths(filePaths);
         } catch {
             // ripgrep's return code != 0 if there are no matches
             return [];

--- a/src/lib/ripgrep.ts
+++ b/src/lib/ripgrep.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+export function parseRipgrepFilePaths(output: string): string[] {
+    // Sorting after ripgrep exits preserves its parallel filesystem traversal.
+    return output
+        .split(/(?:\r\n|\r|\n)/g)
+        .filter(filePath => filePath.length > 0)
+        .sort();
+}

--- a/src/lib/save-declarations.ts
+++ b/src/lib/save-declarations.ts
@@ -12,10 +12,10 @@ import { patchDebugEvents } from './debug-patch';
 import { ParserOptions, SourceSpec } from './source-spec';
 import { logMessage } from './logger';
 import { Fragments } from './fragments';
-import { EventDefinition, EventPropertySignature } from './parser';
+import { EventDefinition } from './event-definition';
 
 interface EventConflictEntry {
-    properties: Record<string, EventPropertySignature>;
+    properties: Record<string, unknown>;
     location: string;
     source: 'GDPR' | 'TS';
 }
@@ -96,7 +96,7 @@ function reportDuplicateEventConflicts(definitions: Map<string, EventConflictEnt
             continue;
         }
 
-        // Check if any overlapping properties have different classification/purpose
+        // Compatible declarations may add properties, but must agree on every overlapping output field.
         let eventHasConflict = false;
         for (let i = 0; i < entries.length && !eventHasConflict; i++) {
             for (let j = i + 1; j < entries.length && !eventHasConflict; j++) {
@@ -104,7 +104,7 @@ function reportDuplicateEventConflicts(definitions: Map<string, EventConflictEnt
                     if (propName in entries[j].properties) {
                         const a = entries[i].properties[propName];
                         const b = entries[j].properties[propName];
-                        if (a.classification !== b.classification || a.purpose !== b.purpose) {
+                        if (JSON.stringify(deepSortKeys(a)) !== JSON.stringify(deepSortKeys(b))) {
                             eventHasConflict = true;
                             break;
                         }

--- a/src/lib/ts-parser.ts
+++ b/src/lib/ts-parser.ts
@@ -8,16 +8,8 @@ import { rgPath } from "@vscode/ripgrep";
 import { makeExclusionsRelativeToSource } from "./operations";
 import { Event, Metadata } from './events';
 import { Property } from "./common-properties";
-
-interface EventPropertySignature {
-    classification: string;
-    purpose: string;
-}
-
-interface EventDefinition {
-    properties: Record<string, EventPropertySignature>;
-    location: string;
-}
+import { parseRipgrepFilePaths } from './ripgrep';
+import { EventDefinition } from './event-definition';
 
 function isMeasurement(type: Type) {
     if (type.isNumber()) {
@@ -242,11 +234,9 @@ export class TsParser {
 
         const ripgrepArgs = ['--files-with-matches', ...rgGlobs, '--no-ignore', 'publicLog2|publicLogError2', this.sourceDir]
         try {
-            const retrieved_paths = cp.execFileSync(rgPath, ripgrepArgs, { encoding: 'ascii' });
-            // Split the paths into an array
-            retrieved_paths.split(/(?:\r\n|\r|\n)/g).filter(path => path && path.length > 0).map((f) => {
-                this.project.addSourceFileAtPathIfExists(f);
-                return f;
+            const retrievedPaths = cp.execFileSync(rgPath, ripgrepArgs, { encoding: 'ascii' });
+            parseRipgrepFilePaths(retrievedPaths).forEach((filePath) => {
+                this.project.addSourceFileAtPathIfExists(filePath);
             });
             // Empty catch because this fails when there are no typescript annotations which causes weird error messages
         } catch {
@@ -262,23 +252,14 @@ export class TsParser {
         return definitions;
     }
 
-    private addEventDefinition(eventName: string, properties: Record<string, EventPropertySignature>, location: string) {
+    private addEventDefinition(eventName: string, properties: Record<string, unknown>, location: string) {
         const existing = this.eventDefinitions.get(eventName) ?? [];
         existing.push({ properties, location });
         this.eventDefinitions.set(eventName, existing);
     }
 
-    private extractConflictProperties(eventProperties: Record<string, unknown>): Record<string, EventPropertySignature> {
-        const result: Record<string, EventPropertySignature> = {};
-        for (const [key, value] of Object.entries(eventProperties)) {
-            if (value && typeof value === 'object' && !Array.isArray(value)) {
-                const obj = value as Record<string, unknown>;
-                if (typeof obj.classification === 'string' && typeof obj.purpose === 'string') {
-                    result[key] = { classification: obj.classification, purpose: obj.purpose };
-                }
-            }
-        }
-        return result;
+    private extractConflictProperties(eventProperties: Record<string, unknown>): Record<string, unknown> {
+        return { ...eventProperties };
     }
 
     public parseFiles() {

--- a/src/tests/mocha/event-tests.ts
+++ b/src/tests/mocha/event-tests.ts
@@ -11,15 +11,26 @@ import { Property } from "../../lib/common-properties";
 import { patchDebugEvents } from "../../lib/debug-patch";
 import { ParserOptions } from "../../lib/source-spec";
 import { Metadata } from "../../lib/events";
+import { parseRipgrepFilePaths } from "../../lib/ripgrep";
 
 const sourceDir = path.join(cwd(), 'src/tests/mocha/resources/source');
 const excludedDirs = [path.join(sourceDir, 'excluded')];
 const sourceDir2 = path.join(cwd(), 'src/tests/mocha/resources/source-1')
 const multipleExcludes = [path.join(sourceDir2, 'excluded'), path.join(sourceDir2, 'folder2')];
 const duplicateEventSourceDir = path.join(cwd(), 'src/tests/mocha/resources/source-duplicate-events');
+const duplicateEventSchemaSourceDir = path.join(cwd(), 'src/tests/mocha/resources/source-duplicate-event-schemas');
+const compatibleDuplicateEventSourceDir = path.join(cwd(), 'src/tests/mocha/resources/source-compatible-duplicate-events');
 const duplicateTsEventSourceDir = path.join(cwd(), 'src/tests/mocha/resources/tsparser-tests/duplicate-conflict-tests');
 
 describe('Events Tests', () => {
+    it('sorts ripgrep file results deterministically', () => {
+        assert.deepStrictEqual(parseRipgrepFilePaths('z/file.ts\r\na/file.ts\nc/file.ts\r'), [
+            'a/file.ts',
+            'c/file.ts',
+            'z/file.ts'
+        ]);
+    });
+
     it('find files - no exclusions', () => {
         const parser = new Parser([sourceDir], [], false, false);
         //@ts-expect-error accessing private method for testing
@@ -97,6 +108,64 @@ describe('Events Tests', () => {
             process.exitCode = previousExitCode;
             console.error = previousConsoleError;
         }
+    });
+
+    it('fails when duplicate GDPR events produce different schemas', async () => {
+        const previousExitCode = process.exitCode;
+        const previousConsoleError = console.error;
+        const consoleErrors: string[] = [];
+        try {
+            process.exitCode = 0;
+            console.error = (...args: unknown[]) => {
+                consoleErrors.push(args.map(arg => String(arg)).join(' '));
+            };
+
+            const parserOptions: ParserOptions = {
+                eventPrefix: '',
+                applyEndpoints: false,
+                patchDebugEvents: false,
+                lowerCaseEvents: false,
+                silenceOutput: true,
+                verbose: false
+            };
+
+            await assert.rejects(() => extractAndResolveDeclarations([{
+                sourceDirs: [duplicateEventSchemaSourceDir],
+                excludedDirs: [],
+                parserOptions
+            }]));
+
+            assert.ok(consoleErrors.some(msg => msg.includes("Duplicate telemetry event declaration 'DuplicateSchemaEvent' has conflicting details at:")));
+            assert.ok(consoleErrors.some(msg => msg.includes('source-duplicate-event-schemas/file1.ts')));
+            assert.ok(consoleErrors.some(msg => msg.includes('source-duplicate-event-schemas/file2.ts')));
+        } finally {
+            process.exitCode = previousExitCode;
+            console.error = previousConsoleError;
+        }
+    });
+
+    it('merges compatible duplicate GDPR event schemas', async () => {
+        const parserOptions: ParserOptions = {
+            eventPrefix: '',
+            applyEndpoints: false,
+            patchDebugEvents: false,
+            lowerCaseEvents: false,
+            silenceOutput: true,
+            verbose: false
+        };
+
+        const declarations = await extractAndResolveDeclarations([{
+            sourceDirs: [compatibleDuplicateEventSourceDir],
+            excludedDirs: [],
+            parserOptions
+        }]);
+
+        assert.deepStrictEqual(Object.keys(declarations.events.CompatibleDuplicateEvent).sort(), [
+            'comment',
+            'firstproperty',
+            'owner',
+            'secondproperty'
+        ]);
     });
 
     it('fails and reports all locations for duplicate TS event conflicts', async () => {

--- a/src/tests/mocha/operations-tests.ts
+++ b/src/tests/mocha/operations-tests.ts
@@ -107,6 +107,23 @@ describe('merge', () => {
     assert.strictEqual(new Set(propertyNames).size, propertyNames.length);
   });
 
+  it('merges table info from overlapping events', () => {
+    const target = new Events();
+    target.dataPoints.push(new Event('shared'));
+
+    const source = new Events();
+    const eventWithTableInfo = new Event('shared');
+    eventWithTableInfo.tableInfo = {
+      name: 'SharedEvents',
+      commonProperties: 'standard',
+      backfill: false
+    };
+    source.dataPoints.push(eventWithTableInfo);
+
+    merge(target, source);
+    assert.deepStrictEqual(target.dataPoints[0].tableInfo, eventWithTableInfo.tableInfo);
+  });
+
   it('merges non-overlapping fragments', () => {
     const target = new Fragments();
     target.dataPoints.push(new Fragment('frag1'));

--- a/src/tests/mocha/resources/source-compatible-duplicate-events/file1.ts
+++ b/src/tests/mocha/resources/source-compatible-duplicate-events/file1.ts
@@ -1,0 +1,8 @@
+/* __GDPR__
+"CompatibleDuplicateEvent" : {
+    "owner" : "team-a",
+    "comment" : "A composed event schema.",
+    "firstProperty" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+}
+*/
+export const first = 1;

--- a/src/tests/mocha/resources/source-compatible-duplicate-events/file2.ts
+++ b/src/tests/mocha/resources/source-compatible-duplicate-events/file2.ts
@@ -1,0 +1,8 @@
+/* __GDPR__
+"CompatibleDuplicateEvent" : {
+    "owner" : "team-a",
+    "comment" : "A composed event schema.",
+    "secondProperty" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+}
+*/
+export const second = 2;

--- a/src/tests/mocha/resources/source-duplicate-event-schemas/file1.ts
+++ b/src/tests/mocha/resources/source-duplicate-event-schemas/file1.ts
@@ -1,0 +1,9 @@
+/* __GDPR__
+"DuplicateSchemaEvent" : {
+    "owner" : "team-a",
+    "comment" : "Tracks when summarization happens and what the outcome was",
+    "outcome" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The success state or failure reason of the summarization." },
+    "detailedOutcome" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "A more detailed error message." }
+}
+*/
+export const first = 1;

--- a/src/tests/mocha/resources/source-duplicate-event-schemas/file2.ts
+++ b/src/tests/mocha/resources/source-duplicate-event-schemas/file2.ts
@@ -1,0 +1,8 @@
+/* __GDPR__
+"DuplicateSchemaEvent" : {
+    "owner" : "team-a",
+    "comment" : "Tracks when summarization happens and what the outcome was",
+    "outcome" : { "classification": "SystemMetaData", "purpose": "FeatureInsight", "comment": "The success state." }
+}
+*/
+export const second = 2;


### PR DESCRIPTION
Fix duplicate telemetry declarations whose output previously depended on ripgrep discovery order.

## Changes

- compare every overlapping emitted field, rather than only `classification` and `purpose`
- merge compatible duplicate declarations so disjoint properties and table metadata are retained
- sort ripgrep file results in Node after search completes, preserving ripgrep's parallel traversal
- cover conflicting schemas, compatible composition, deterministic path ordering, and table metadata

Fixes #70

## Validation

- `npm run compile`
- `npm run lint`
- focused event and operation suites: 48 passing
- full suite: 82 passing; 4 CLI subprocess tests exceed their existing hardcoded 3-second timeout on Windows (also reproduce when run in isolation)